### PR TITLE
Fix bug in static constructor in LightMoney

### DIFF
--- a/src/BTCPayServer.Lightning.Common/LightMoney.cs
+++ b/src/BTCPayServer.Lightning.Common/LightMoney.cs
@@ -196,7 +196,7 @@ namespace BTCPayServer.Lightning
         {
             // overflow safe.
             // decimal operations are checked by default
-            return new LightMoney(coins * (ulong)LightMoneyUnit.BTC, LightMoneyUnit.MilliBTC);
+            return new LightMoney(coins * (ulong)LightMoneyUnit.BTC, LightMoneyUnit.MilliSatoshi);
         }
 
         public static LightMoney Bits(decimal bits)
@@ -210,12 +210,12 @@ namespace BTCPayServer.Lightning
         {
             // overflow safe.
             // decimal operations are checked by default
-            return new LightMoney(cents * (ulong)LightMoneyUnit.Bit, LightMoneyUnit.MilliBTC);
+            return new LightMoney(cents * (ulong)LightMoneyUnit.Bit, LightMoneyUnit.MilliSatoshi);
         }
 
         public static LightMoney Satoshis(decimal sats)
         {
-            return new LightMoney(sats * (ulong)LightMoneyUnit.Satoshi, LightMoneyUnit.MilliBTC);
+            return new LightMoney(sats * (ulong)LightMoneyUnit.Satoshi, LightMoneyUnit.MilliSatoshi);
         }
 
         public static LightMoney Satoshis(ulong sats)

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Xunit;
 using System.Linq;
@@ -163,6 +163,16 @@ namespace BTCPayServer.Lightning.Tests
                     Assert.Throws<OperationCanceledException>(() => waitTask3.GetAwaiter().GetResult());
                 }
             }
+        }
+
+        [Fact]
+        public void LightMoneyOverflowTest()
+        {
+            var maxSupply = 21_000_000m;
+            LightMoney.Coins(maxSupply);
+            LightMoney.Bits(maxSupply * (decimal)LightMoneyUnit.Bit);
+            LightMoney.Cents(maxSupply * (decimal)LightMoneyUnit.Bit);
+            LightMoney.Satoshis(maxSupply * (decimal)LightMoneyUnit.Satoshi);
         }
 
         [Fact]


### PR DESCRIPTION
It has been multiplying the value twice

1. in public static constructors (e.g `LightMoney.Satoshis` ) 
2. in the default constructor (i.e. `LightMoney(decimal amount LightMoneyUnit unit)` )

which will result to much larger value than a user expects.