### PR TITLE
Restore eclair test

### DIFF
--- a/tests/Tester.cs
+++ b/tests/Tester.cs
@@ -91,7 +91,7 @@ namespace BTCPayServer.Lightning.Tests
 		{
 			yield return ("C-Lightning", CreateCLightningClient(), CreateCLightningClientDest());
 			yield return ("LND", CreateLndClient(), CreateLndClientDest());
-			//yield return ("Eclair", CreateEclairClient(), CreateEclairClientDest());
+			yield return ("Eclair", CreateEclairClient(), CreateEclairClientDest());
 		}
 	}
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -161,7 +161,7 @@ services:
   eclair:
     restart: unless-stopped
     stop_signal: SIGKILL
-    image: acinq/eclair:btcpay
+    image: acinq/eclair:v0.3.3
     environment:
       JAVA_OPTS: |
         -Xmx256m
@@ -201,7 +201,7 @@ services:
   eclair_dest:
     restart: unless-stopped
     stop_signal: SIGKILL
-    image: acinq/eclair:btcpay
+    image: acinq/eclair:v0.3.3
     environment:
       JAVA_OPTS: |
         -Xmx256m

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -16,6 +16,7 @@ services:
         whitelist=0.0.0.0/0
         zmqpubrawblock=tcp://0.0.0.0:28332
         zmqpubrawtx=tcp://0.0.0.0:28333
+        txindex=1
         deprecatedrpc=signrawtransaction
     ports: 
       - "37393:43782"


### PR DESCRIPTION
This PR enable bitcoind `txindex` during test as it's required by Eclair implementation and re-enable eclair's test. I would also like to update the eclair version used in the test to the newly released 0.3.3 but we're currently experiencing some issues with the dockerhub integration, i'll update this PR if the new image becomes available.

Fixes #26 