### PR TITLE
LND: Simple channel closing implementation

### DIFF
--- a/src/BTCPayServer.Lightning.Common/CloseChannelRequest.cs
+++ b/src/BTCPayServer.Lightning.Common/CloseChannelRequest.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace BTCPayServer.Lightning
+{
+    public class CloseChannelRequest
+    {
+        public NodeInfo NodeInfo
+        {
+            get; set;
+        }
+        public string ChannelPointFundingTxIdStr
+        {
+            get; set;
+        }
+        public long ChannelPointOutputIndex
+        {
+            get; set;
+        }
+        public static void AssertIsSane(CloseChannelRequest closeChannelRequest)
+        {
+            if (closeChannelRequest == null)
+                throw new ArgumentNullException(nameof(closeChannelRequest));
+            if (closeChannelRequest.ChannelPointFundingTxIdStr == null)
+                throw new ArgumentNullException(nameof(closeChannelRequest.ChannelPointFundingTxIdStr));
+        }
+    }
+}

--- a/src/BTCPayServer.Lightning.Common/CloseChannelResponse.cs
+++ b/src/BTCPayServer.Lightning.Common/CloseChannelResponse.cs
@@ -1,0 +1,20 @@
+﻿namespace BTCPayServer.Lightning
+{
+    public enum CloseChannelResult
+    {
+        Ok,
+        Failed,
+    }
+
+    public class CloseChannelResponse
+    {
+        public CloseChannelResponse(CloseChannelResult result)
+        {
+            Result = result;
+        }
+        public CloseChannelResult Result
+        {
+            get; set;
+        }
+    }
+}

--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -427,6 +427,21 @@ namespace BTCPayServer.Lightning.LND
             }
         }
 
+        public async Task<CloseChannelResponse> CloseChannel(CloseChannelRequest closeChannelRequest, CancellationToken cancellation)
+        {
+            CloseChannelRequest.AssertIsSane(closeChannelRequest);
+            cancellation.ThrowIfCancellationRequested();
+            try
+            {
+                var result = await this.SwaggerClient.CloseChannelAsync(closeChannelRequest.ChannelPointFundingTxIdStr, closeChannelRequest.ChannelPointOutputIndex, cancellation);
+                return new CloseChannelResponse(CloseChannelResult.Ok);
+            }
+            catch (Exception)
+            {
+                return new CloseChannelResponse(CloseChannelResult.Failed);
+            }
+        }
+
         async Task<BitcoinAddress> ILightningClient.GetDepositAddress()
         {
             return BitcoinAddress.Create((await SwaggerClient.NewWitnessAddressAsync()).Address, Network);


### PR DESCRIPTION
Adds a `CloseChannel` method to `LndClient` which delegates to the existing `LndSwaggerClient.CloseChannelAsync` method.