### PR TITLE
Switching to using container built from non-forked codebase

### DIFF
--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -56,14 +56,14 @@ namespace BTCPayServer.Lightning.Tests
 				? new[]
 				{
 					"type=charge;server=http://api-token:foiewnccewuify@charge:9112;allowinsecure=true",
-					"type=lnd-rest;server=https://lnd_dest:8080;allowinsecure=true",
+					"type=lnd-rest;server=http://lnd_dest:8080;allowinsecure=true",
 					"type=clightning;server=tcp://lightningd:9835",
 					"type=eclair;server=http://eclair:8080;password=bukkake"
 				}
 				: new[]
 				{
 					"type=charge;server=http://api-token:foiewnccewuify@127.0.0.1:37462;allowinsecure=true",
-					"type=lnd-rest;server=https://127.0.0.1:42802;allowinsecure=true",
+					"type=lnd-rest;server=http://127.0.0.1:42802;allowinsecure=true",
 					"type=clightning;server=tcp://127.0.0.1:48532",
 					"type=eclair;server=http://127.0.0.1:4570;password=bukkake"
 				};

--- a/tests/Tester.cs
+++ b/tests/Tester.cs
@@ -36,7 +36,7 @@ namespace BTCPayServer.Lightning.Tests
 			return new LndClient(new LndRestSettings()
 			{
 				AllowInsecure = true,
-				Uri = new Uri(CommonTests.Docker ? "https://lnd:8080" : "https://127.0.0.1:32736")
+				Uri = new Uri(CommonTests.Docker ? "http://lnd:8080" : "http://127.0.0.1:32736")
 			}, Network.RegTest);
 		}
 
@@ -75,7 +75,7 @@ namespace BTCPayServer.Lightning.Tests
 			return new LndClient(new LndRestSettings()
 			{
 				AllowInsecure = true,
-				Uri = new Uri(CommonTests.Docker ? "https://lnd_dest:8080" : "https://127.0.0.1:42802"),
+				Uri = new Uri(CommonTests.Docker ? "http://lnd_dest:8080" : "http://127.0.0.1:42802"),
 			}, Network.RegTest);
 		}
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -105,19 +105,23 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.11.0-beta
+    image: btcpayserver/lnd:v0.11.x-beta-notls
+    hostname: btcpay_lightning_tests_lnd
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
+      LND_REST_LISTEN_HOST: https://btcpay_lightning_tests_lnd:8080
       LND_EXTRA_ARGS: |
-        restlisten=0.0.0.0:8080
+        restlisten=btcpay_lightning_tests_lnd:8080
         rpclisten=127.0.0.1:10008
-        rpclisten=0.0.0.0:10009
+        rpclisten=btcpay_lightning_tests_lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
+        bitcoind.rpcuser=ceiwHEbqWI83
+        bitcoind.rpcpass=DwubwWsoo3
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
-        externalip=lnd:9735
+        externalip=btcpay_lightning_tests_lnd:9735
         bitcoin.defaultchanconfs=1
         no-macaroons=1
         debuglevel=debug
@@ -134,19 +138,23 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.11.0-beta
+    image: btcpayserver/lnd:v0.11.x-beta-notls
+    hostname: btcpay_lightning_tests_lnd_dest
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
+      LND_REST_LISTEN_HOST: https://btcpay_lightning_tests_lnd_dest:8080
       LND_EXTRA_ARGS: |
-        restlisten=0.0.0.0:8080
+        restlisten=btcpay_lightning_tests_lnd_dest:8080
         rpclisten=127.0.0.1:10008
-        rpclisten=0.0.0.0:10009
+        rpclisten=btcpay_lightning_tests_lnd_dest:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
+        bitcoind.rpcuser=ceiwHEbqWI83
+        bitcoind.rpcpass=DwubwWsoo3
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
-        externalip=lnd_dest:9735
+        externalip=btcpay_lightning_tests_lnd_dest:9735
         bitcoin.defaultchanconfs=1
         no-macaroons=1
         debuglevel=debug

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -105,7 +105,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.11.x-beta-notls
+    image: btcpayserver/lnd:v0.12.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -125,7 +125,7 @@ services:
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
-        notls=1
+        no-rest-tls=1
     ports:
       - "32736:8080"
     expose:
@@ -138,7 +138,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.11.x-beta-notls
+    image: btcpayserver/lnd:v0.12.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -158,7 +158,7 @@ services:
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
-        notls=1
+        no-rest-tls=1
     ports:
       - "42802:8080"
     expose:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -106,26 +106,26 @@ services:
   lnd:
     restart: unless-stopped
     image: btcpayserver/lnd:v0.11.x-beta-notls
-    hostname: btcpay_lightning_tests_lnd
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
-      LND_REST_LISTEN_HOST: https://btcpay_lightning_tests_lnd:8080
+      LND_REST_LISTEN_HOST: http://lnd:8080
       LND_EXTRA_ARGS: |
-        restlisten=btcpay_lightning_tests_lnd:8080
+        restlisten=lnd:8080
         rpclisten=127.0.0.1:10008
-        rpclisten=btcpay_lightning_tests_lnd:10009
+        rpclisten=lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
         bitcoind.rpcuser=ceiwHEbqWI83
         bitcoind.rpcpass=DwubwWsoo3
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
-        externalip=btcpay_lightning_tests_lnd:9735
+        externalip=lnd:9735
         bitcoin.defaultchanconfs=1
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
+        notls=1
     ports:
       - "32736:8080"
     expose:
@@ -139,26 +139,26 @@ services:
   lnd_dest:
     restart: unless-stopped
     image: btcpayserver/lnd:v0.11.x-beta-notls
-    hostname: btcpay_lightning_tests_lnd_dest
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
-      LND_REST_LISTEN_HOST: https://btcpay_lightning_tests_lnd_dest:8080
+      LND_REST_LISTEN_HOST: http://lnd_dest:8080
       LND_EXTRA_ARGS: |
-        restlisten=btcpay_lightning_tests_lnd_dest:8080
+        restlisten=lnd_dest:8080
         rpclisten=127.0.0.1:10008
-        rpclisten=btcpay_lightning_tests_lnd_dest:10009
+        rpclisten=lnd_dest:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
         bitcoind.rpcuser=ceiwHEbqWI83
         bitcoind.rpcpass=DwubwWsoo3
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
-        externalip=btcpay_lightning_tests_lnd_dest:9735
+        externalip=lnd_dest:9735
         bitcoin.defaultchanconfs=1
         no-macaroons=1
         debuglevel=debug
         trickledelay=1000
+        notls=1
     ports:
       - "42802:8080"
     expose:


### PR DESCRIPTION
I've built a custom Docker image `btcpayserver/lnd:v0.11.x-beta-notls` by adding our scripts on top of @halseth branch, see last 2 commits here:
https://github.com/btcpayserver/lnd/commits/option-no-tls

In this PR you can see how I'm setting `hostname` and then utilizing it through lnd.conf variables. It seems to be working as expected.

You can see that all tests are passing - if things look good on your machine I guess you can merge. 

I've tried it in `btcpayserver` and it also works, the only tricky thing is that it seems 0.0.0.0 rest listener was working on both HTTP and HTTPS. I've needed to modify some variables in order to make things work (introduced `LND_REST_LISTEN_HOST` for wallet auto-init script)... but no other obvious side effect.

