### PR TITLE
Add LNbank client

### DIFF
--- a/BTCPayServer.Lightning.sln
+++ b/BTCPayServer.Lightning.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BTCPayServer.Lightning.Ecla
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BTCPayServer.Lightning.Ptarmigan", "src\BTCPayServer.Lightning.Ptarmigan\BTCPayServer.Lightning.Ptarmigan.csproj", "{58B60560-55F2-4F95-98E9-F532D8282492}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BTCPayServer.Lightning.LNbank", "src\BTCPayServer.Lightning.LNbank\BTCPayServer.Lightning.LNbank.csproj", "{4057015B-9D8A-411A-B7C2-3342D9F53BD0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,18 @@ Global
 		{58B60560-55F2-4F95-98E9-F532D8282492}.Release|x64.Build.0 = Release|Any CPU
 		{58B60560-55F2-4F95-98E9-F532D8282492}.Release|x86.ActiveCfg = Release|Any CPU
 		{58B60560-55F2-4F95-98E9-F532D8282492}.Release|x86.Build.0 = Release|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Debug|x64.Build.0 = Debug|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Debug|x86.Build.0 = Debug|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Release|x64.ActiveCfg = Release|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Release|x64.Build.0 = Release|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Release|x86.ActiveCfg = Release|Any CPU
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -142,6 +156,7 @@ Global
 		{691B1F98-4CC3-47FF-B3F3-B97FC0AB4C94} = {5BA1A1B2-2713-4CF4-9B63-087531598797}
 		{542D3F73-7067-4873-89EF-FA0345E32C04} = {5BA1A1B2-2713-4CF4-9B63-087531598797}
 		{58B60560-55F2-4F95-98E9-F532D8282492} = {5BA1A1B2-2713-4CF4-9B63-087531598797}
+		{4057015B-9D8A-411A-B7C2-3342D9F53BD0} = {5BA1A1B2-2713-4CF4-9B63-087531598797}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5E91C820-C650-4ACA-B064-05ECE0A74CE8}

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The `connectionString` encapsulates the necessary information BTCPay needs to co
 * `type=charge;server=https://charge:8080/;api-token=myapitoken...`
 * `type=charge;server=https://charge:8080/;cookiefilepath=/path/to/cookie...`
 * `type=eclair;server=http://127.0.0.1:4570;password=eclairpass`
-* `type=lnbank;server=http://lnbank:5000;api-token=myapitoken;wallet-id=MY-LNBANK-WALLET-ID`
+* `type=lnbank;server=http://lnbank:5000;api-token=myapitoken;wallet-id=MY-LNBANK-WALLET-ID;allowinsecure=true`
 * `type=lnbank;server=https://mybtcpay.com/lnbank;api-token=myapitoken;wallet-id=MY-LNBANK-WALLET-ID`
 
 Note that `bitcoin-host` and `bitcoin-auth` are optional, only useful if you want to call `ILightningClient.GetDepositAddress` on Eclair.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The `connectionString` encapsulates the necessary information BTCPay needs to co
 * `type=charge;server=https://charge:8080/;api-token=myapitoken...`
 * `type=charge;server=https://charge:8080/;cookiefilepath=/path/to/cookie...`
 * `type=eclair;server=http://127.0.0.1:4570;password=eclairpass`
+* `type=lnbank;server=http://lnbank:5000;api-token=myapitoken`
+* `type=lnbank;server=https://mybtcpay.com/lnbank;api-token=myapitoken`
 
 Note that `bitcoin-host` and `bitcoin-auth` are optional, only useful if you want to call `ILightningClient.GetDepositAddress` on Eclair.
 We expect this won't be needed in the future.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ The `connectionString` encapsulates the necessary information BTCPay needs to co
 
 #### Examples
 
-* `type`=clightning;`server`=unix://root/.lightning/lightning-rpc
-* `type`=clightning;`server`=tcp://1.1.1.1:27743/
-* `type`=lnd-rest;`server`=<span>http://mylnd:8080/</span>;`macaroonfilepath`=/root/.lnd/admin.macaroon;allowinsecure=true
-* `type`=lnd-rest;`server`=<span>https://mylnd:8080/</span>;`macaroon`=abef263adfe...
-* `type`=lnd-rest;`server`=<span>https://mylnd:8080/</span>;`macaroon`=abef263adfe...;`certthumbprint`=abef263adfe...
-* `type`=charge;`server`=<span>https://charge:8080/</span>;`api-token`=myapitoken...
-* `type`=charge;`server`=<span>https://charge:8080/</span>;`cookiefilepath`=/path/to/cookie...
-* `type`=eclair;`server`=<span>http://127.0.0.1:4570</span>;`password`=eclairpass
+* `type=clightning;server=unix://root/.lightning/lightning-rpc`
+* `type=clightning;server=tcp://1.1.1.1:27743/`
+* `type=lnd-rest;server=http://mylnd:8080/;macaroonfilepath=/root/.lnd/admin.macaroon;allowinsecure=true`
+* `type=lnd-rest;server=https://mylnd:8080/;macaroon=abef263adfe...`
+* `type=lnd-rest;server=https://mylnd:8080/;macaroon=abef263adfe...;certthumbprint=abef263adfe...`
+* `type=charge;server=https://charge:8080/;api-token=myapitoken...`
+* `type=charge;server=https://charge:8080/;cookiefilepath=/path/to/cookie...`
+* `type=eclair;server=http://127.0.0.1:4570;password=eclairpass`
 
 Note that `bitcoin-host` and `bitcoin-auth` are optional, only useful if you want to call `ILightningClient.GetDepositAddress` on Eclair.
 We expect this won't be needed in the future.
@@ -72,7 +72,7 @@ We expect this won't be needed in the future.
 Note that the `certthumbprint` to connect to your LND node can be obtained through this command line:
 
 ```bash
-openssl x509 -noout -fingerprint -sha256 -inform pem -in /root/.lnd/tls.cert
+openssl x509 -noout -fingerprint -sha256 -in /root/.lnd/tls.cert | sed -e 's/.*=//;s/://g'
 ```
 
 You can omit `certthumprint` if you the certificate is trusted by your machine
@@ -95,6 +95,7 @@ docker-compose up
 Then you can run and debug the tests with visual studio or visual studio code.
 
 If you want to use command line:
+
 ```bash
 cd tests
 dotnet test

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The `connectionString` encapsulates the necessary information BTCPay needs to co
 * `type=charge;server=https://charge:8080/;api-token=myapitoken...`
 * `type=charge;server=https://charge:8080/;cookiefilepath=/path/to/cookie...`
 * `type=eclair;server=http://127.0.0.1:4570;password=eclairpass`
-* `type=lnbank;server=http://lnbank:5000;api-token=myapitoken`
-* `type=lnbank;server=https://mybtcpay.com/lnbank;api-token=myapitoken`
+* `type=lnbank;server=http://lnbank:5000;api-token=myapitoken;wallet-id=MY-LNBANK-WALLET-ID`
+* `type=lnbank;server=https://mybtcpay.com/lnbank;api-token=myapitoken;wallet-id=MY-LNBANK-WALLET-ID`
 
 Note that `bitcoin-host` and `bitcoin-auth` are optional, only useful if you want to call `ILightningClient.GetDepositAddress` on Eclair.
 We expect this won't be needed in the future.

--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -22,6 +22,6 @@
 		<ProjectReference Include="..\BTCPayServer.Lightning.Ptarmigan\BTCPayServer.Lightning.Ptarmigan.csproj" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.0.0"></PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10"></PackageReference>
   </ItemGroup>
 </Project>

--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -17,6 +17,7 @@
 		<ProjectReference Include="..\BTCPayServer.Lightning.Charge\BTCPayServer.Lightning.Charge.csproj" />
 		<ProjectReference Include="..\BTCPayServer.Lightning.CLightning\BTCPayServer.Lightning.CLightning.csproj" />
 		<ProjectReference Include="..\BTCPayServer.Lightning.Eclair\BTCPayServer.Lightning.Eclair.csproj" />
+		<ProjectReference Include="..\BTCPayServer.Lightning.LNbank\BTCPayServer.Lightning.LNbank.csproj" />
 		<ProjectReference Include="..\BTCPayServer.Lightning.LND\BTCPayServer.Lightning.LND.csproj" />
 		<ProjectReference Include="..\BTCPayServer.Lightning.Ptarmigan\BTCPayServer.Lightning.Ptarmigan.csproj" />
 	</ItemGroup>

--- a/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
+++ b/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using BTCPayServer.Lightning.Charge;
 using BTCPayServer.Lightning.CLightning;
 using BTCPayServer.Lightning.Eclair;
+using BTCPayServer.Lightning.LNbank;
 using BTCPayServer.Lightning.LND;
 using BTCPayServer.Lightning.Ptarmigan;
 using NBitcoin;
@@ -87,6 +88,10 @@ namespace BTCPayServer.Lightning
                         }
                         : null;
                 return new PtarmiganLightningClient(connectionString.BaseUri, connectionString.ApiToken, Network, rpcClient, HttpClient);
+            }
+            else if (connectionString.ConnectionType == LightningConnectionType.LNbank)
+            {
+                return new LNbankLightningClient(connectionString.BaseUri, connectionString.ApiToken, Network, HttpClient);
             }
             else
                 throw new NotSupportedException(

--- a/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
+++ b/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
@@ -91,7 +91,7 @@ namespace BTCPayServer.Lightning
             }
             else if (connectionString.ConnectionType == LightningConnectionType.LNbank)
             {
-                return new LNbankLightningClient(connectionString.BaseUri, connectionString.ApiToken, Network, HttpClient);
+                return new LNbankLightningClient(connectionString.BaseUri, connectionString.ApiToken, connectionString.WalletId, Network, HttpClient);
             }
             else
                 throw new NotSupportedException(

--- a/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
+++ b/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
@@ -91,7 +91,7 @@ namespace BTCPayServer.Lightning
             }
             else if (connectionString.ConnectionType == LightningConnectionType.LNbank)
             {
-                return new LNbankLightningClient(connectionString.BaseUri, connectionString.ApiToken, connectionString.WalletId, Network, HttpClient);
+                return new LNbankLightningClient(connectionString.BaseUri, connectionString.ApiToken, Network, HttpClient);
             }
             else
                 throw new NotSupportedException(

--- a/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
+++ b/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
@@ -399,8 +399,16 @@ namespace BTCPayServer.Lightning
                         return false;
                     }
 
+                    var lnbankWalletId = Take(keyValues, "wallet-id");
+                    if (lnbankWalletId == null)
+                    {
+                        error = $"The key 'wallet-id' is not found";
+                        return false;
+                    }
+
                     result.BaseUri = lnbankUri;
                     result.ApiToken = lnbankApiToken;
+                    result.WalletId = lnbankWalletId;
 
                     break;
                 default:
@@ -518,6 +526,8 @@ namespace BTCPayServer.Lightning
 
         public string ApiToken { get; set; }
 
+        public string WalletId { get; set; }
+        
         public Uri ToUri(bool withCredentials)
         {
             if (withCredentials)
@@ -611,6 +621,9 @@ namespace BTCPayServer.Lightning
                     break;
                 case LightningConnectionType.Ptarmigan:
                     builder.Append($";server={BaseUri}");
+                    break;
+                case LightningConnectionType.LNbank:
+                    builder.Append($";server={BaseUri};api-token={ApiToken};wallet-id={WalletId}");
                     break;
                 default:
                     throw new NotSupportedException(type);

--- a/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
+++ b/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
@@ -1,10 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.IO;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
-using System.Threading.Tasks;
 using NBitcoin.DataEncoders;
 
 namespace BTCPayServer.Lightning
@@ -12,8 +10,11 @@ namespace BTCPayServer.Lightning
     public enum LightningConnectionType
     {
         Charge,
+        [Display(Name = "c-lightning")]
         CLightning,
+        [Display(Name = "LND (REST)")]
         LndREST,
+        [Display(Name = "LND (gRPC)")]
         LndGRPC,
         Eclair,
         Ptarmigan,

--- a/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
+++ b/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
@@ -419,16 +419,8 @@ namespace BTCPayServer.Lightning
                             return false;
                         }
 
-                        var walletId = Take(keyValues, "wallet-id");
-                        if (walletId == null)
-                        {
-                            error = "The key 'wallet-id' is not found";
-                            return false;
-                        }
-
                         result.BaseUri = uri;
                         result.ApiToken = apiToken;
-                        result.WalletId = walletId;
                     }
                     break;
                 default:
@@ -545,8 +537,6 @@ namespace BTCPayServer.Lightning
         public string BitcoinAuth { get; set; }
 
         public string ApiToken { get; set; }
-
-        public string WalletId { get; set; }
         
         public Uri ToUri(bool withCredentials)
         {
@@ -643,7 +633,7 @@ namespace BTCPayServer.Lightning
                     builder.Append($";server={BaseUri}");
                     break;
                 case LightningConnectionType.LNbank:
-                    builder.Append($";server={BaseUri};api-token={ApiToken};wallet-id={WalletId}");
+                    builder.Append($";server={BaseUri};api-token={ApiToken}");
                     if (AllowInsecure)
                     {
                         builder.Append(";allowinsecure=true");

--- a/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
+++ b/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
@@ -16,7 +16,8 @@ namespace BTCPayServer.Lightning
         LndREST,
         LndGRPC,
         Eclair,
-        Ptarmigan
+        Ptarmigan,
+        LNbank
     }
     public class LightningConnectionString
     {
@@ -31,6 +32,7 @@ namespace BTCPayServer.Lightning
             typeMapping.Add("lnd-grpc", LightningConnectionType.LndGRPC);
             typeMapping.Add("eclair", LightningConnectionType.Eclair);
             typeMapping.Add("ptarmigan", LightningConnectionType.Ptarmigan);
+            typeMapping.Add("lnbank", LightningConnectionType.LNbank);
             typeMappingReverse = new Dictionary<LightningConnectionType, string>();
             foreach (var kv in typeMapping)
             {
@@ -318,8 +320,6 @@ namespace BTCPayServer.Lightning
                     }
                     break;
                 case LightningConnectionType.Eclair:
-                    
-                    
                     var eclairserver = Take(keyValues, "server");
                     
                     if (eclairserver == null)
@@ -352,7 +352,6 @@ namespace BTCPayServer.Lightning
 
                     break;
                 case LightningConnectionType.Ptarmigan:
-
                     var ptarmiganserver = Take(keyValues, "server");
 
                     if (ptarmiganserver == null)
@@ -376,6 +375,32 @@ namespace BTCPayServer.Lightning
 
                     result.BaseUri = ptarmiganuri;
                     result.ApiToken = ptarmiganApiToken;
+
+                    break;
+                case LightningConnectionType.LNbank:
+                    var lnbankServer = Take(keyValues, "server");
+
+                    if (lnbankServer == null)
+                    {
+                        error = $"The key 'server' is mandatory for LNbank connection strings";
+                        return false;
+                    }
+                    if (!Uri.TryCreate(lnbankServer, UriKind.Absolute, out var lnbankUri)
+                        || (lnbankUri.Scheme != "http" && lnbankUri.Scheme != "https"))
+                    {
+                        error = $"The key 'server' should be an URI starting by http:// or https://";
+                        return false;
+                    }
+
+                    var lnbankApiToken = Take(keyValues, "api-token");
+                    if (lnbankApiToken == null)
+                    {
+                        error = $"The key 'api-token' is not found";
+                        return false;
+                    }
+
+                    result.BaseUri = lnbankUri;
+                    result.ApiToken = lnbankApiToken;
 
                     break;
                 default:

--- a/src/BTCPayServer.Lightning.Common/ConnectionResult.cs
+++ b/src/BTCPayServer.Lightning.Common/ConnectionResult.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BTCPayServer.Lightning
+﻿namespace BTCPayServer.Lightning
 {
 	public enum ConnectionResult
 	{

--- a/src/BTCPayServer.Lightning.Common/OpenChannelResponse.cs
+++ b/src/BTCPayServer.Lightning.Common/OpenChannelResponse.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BTCPayServer.Lightning
+﻿namespace BTCPayServer.Lightning
 {
     public enum OpenChannelResult
     {

--- a/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
+++ b/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
@@ -2,6 +2,13 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
+        <Version>1.0.0</Version>
+        <PackageId>BTCPayServer.Lightning.LNBank</PackageId>
+        <Description>Client library for LNBank to build Lightning Network Apps in C#.</Description>
+        <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</RepositoryUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageTags>lightning;bitcoin;lnbank;lapps</PackageTags>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
+++ b/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\BTCPayServer.Lightning.Common\BTCPayServer.Lightning.Common.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
+++ b/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
@@ -8,4 +8,8 @@
       <ProjectReference Include="..\BTCPayServer.Lightning.Common\BTCPayServer.Lightning.Common.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.10" />
+    </ItemGroup>
+
 </Project>

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -1,6 +1,18 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Net;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http.Headers;
+using System.Text;
+using BTCPayServer.Lightning.LNbank.Models;
+using Newtonsoft.Json;
 using NBitcoin;
+using NBitcoin.JsonConverters;
+using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Lightning.LNbank
 {
@@ -16,6 +28,125 @@ namespace BTCPayServer.Lightning.LNbank
             _walletId = walletId;
             _httpClient = httpClient;
             _network = network;
+
+            // HTTP
+            _httpClient.BaseAddress = new Uri($"{baseUri}api/lightning/");
+            _httpClient.DefaultRequestHeaders.Add("User-Agent", "BTCPayServer.Lightning.LNbankLightningClient");
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("token", apiToken);
+
+            // JSON
+            var serializerSettings = new JsonSerializerSettings();
+            Serializer.RegisterFrontConverters(serializerSettings, network);
+            _serializer = JsonSerializer.Create(serializerSettings);
+        }
+
+        public async Task<NodeInfoData> GetInfo(CancellationToken cancellation)
+        {
+            return await Get<NodeInfoData>("info", cancellation);
+        }
+
+        public async Task<InvoiceData> GetInvoice(string invoiceId, CancellationToken cancellation)
+        {
+            return await Get<InvoiceData>($"invoice/{invoiceId}", cancellation);
+        }
+
+        public async Task<BitcoinAddress> GetDepositAddress(CancellationToken cancellation = default)
+        {
+            var addr = await Post<EmptyRequestModel, string>("deposit-address", null, cancellation);
+
+            return BitcoinAddress.Create(addr, _network);
+        }
+
+        public async Task<ChannelData[]> ListChannels(CancellationToken cancellation)
+        {
+            return await Get<ChannelData[]>("channels", cancellation);
+        }
+
+        public async Task<InvoiceData> CreateInvoice(LightMoney amount, string description, TimeSpan expiry, CancellationToken cancellation)
+        {
+            var payload = new CreateInvoiceRequest
+            {
+                WalletId = _walletId,
+                Amount = amount,
+                Description = description,
+                Expiry = expiry
+            };
+            return await Post<CreateInvoiceRequest, InvoiceData>("invoice", payload, cancellation);
+        }
+
+        public async Task<PayResponse> Pay(string bolt11, CancellationToken cancellation)
+        {
+            var payload = new PayInvoiceRequest
+            {
+                WalletId = _walletId,
+                PaymentRequest = bolt11
+            };
+            return await Post<PayInvoiceRequest, PayResponse>("pay", payload, cancellation);
+        }
+
+        public async Task<OpenChannelResponse> OpenChannel(NodeInfo nodeUri, Money amount, FeeRate feeRate, CancellationToken cancellation)
+        {
+            var payload = new CreateChannelRequest
+            {
+                NodeURI = nodeUri.ToString(),
+                ChannelAmount = amount,
+                FeeRate = feeRate
+            };
+            return await Post<CreateChannelRequest, OpenChannelResponse>("channels", payload, cancellation);
+        }
+
+        private async Task<TResponse> Get<TResponse>(string path, CancellationToken cancellation)
+        {
+            return await Send<EmptyRequestModel, TResponse>(HttpMethod.Get, path, null, cancellation);
+        }
+
+        private async Task<TResponse> Post<TRequest, TResponse>(string path, TRequest payload, CancellationToken cancellation)
+        {
+            return await Send<TRequest, TResponse>(HttpMethod.Post, path, payload, cancellation);
+        }
+
+        private async Task<TResponse> Send<TRequest, TResponse>(HttpMethod method, string path, TRequest payload, CancellationToken cancellation)
+        {
+            HttpContent content = null;
+            if (payload != null)
+            {
+                var payloadJson = JsonConvert.SerializeObject(payload);
+                content = new StringContent(payloadJson, Encoding.UTF8, "application/json");
+            }
+            var req = new HttpRequestMessage
+            {
+                RequestUri = new Uri(_httpClient.BaseAddress + path),
+                Method = method,
+                Content = content
+            };
+            var res = await _httpClient.SendAsync(req, cancellation);
+            var str = await res.Content.ReadAsStringAsync();
+
+            if (!res.IsSuccessStatusCode)
+            {
+                throw new LNbankApiException(str);
+            }
+
+            var data = JsonConvert.DeserializeObject<TResponse>(str);
+
+            return data;
+        }
+
+        internal class EmptyRequestModel
+        {
+        }
+
+        internal class LNbankApiException : Exception
+        {
+            public ErrorData Error { get; set; }
+
+            public override string Message => Error?.Detail;
+            public string ErrorCode => Error?.Code;
+            public LNbankApiException(string json)
+            {
+                Error = JsonConvert.DeserializeObject<ErrorData>(json);
+            }
         }
     }
 }

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -28,7 +28,7 @@ namespace BTCPayServer.Lightning.LNbank
             _httpClient.BaseAddress = new Uri($"{baseUri}api/lightning/");
             _httpClient.DefaultRequestHeaders.Add("User-Agent", "BTCPayServer.Lightning.LNbankLightningClient");
             _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("token", apiToken);
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
 
             // JSON
             var serializerSettings = new JsonSerializerSettings();

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -121,7 +121,7 @@ namespace BTCPayServer.Lightning.LNbank
 
             var req = new HttpRequestMessage
             {
-                RequestUri = new Uri($"{_baseUri}api/lightning/{path}"),
+                RequestUri = new Uri($"{_baseUri}/plugins/lnbank/api/lightning/{path}"),
                 Method = method,
                 Content = content
             };

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -42,7 +42,7 @@ namespace BTCPayServer.Lightning.LNbank
         {
             return await Get<InvoiceData>($"invoice/{invoiceId}", cancellation);
         }
-        
+
         public async Task CancelInvoice(string invoiceId,CancellationToken cancellation)
         {
             _ = await Send<EmptyRequestModel, EmptyRequestModel>(HttpMethod.Delete, $"invoice/{invoiceId}", new EmptyRequestModel(), cancellation);
@@ -121,7 +121,7 @@ namespace BTCPayServer.Lightning.LNbank
 
             var req = new HttpRequestMessage
             {
-                RequestUri = new Uri($"{_baseUri}/plugins/lnbank/api/lightning/{path}"),
+                RequestUri = new Uri($"{_baseUri}plugins/lnbank/api/lightning/{path}"),
                 Method = method,
                 Content = content
             };
@@ -140,7 +140,7 @@ namespace BTCPayServer.Lightning.LNbank
 
             if (typeof(TResponse) == typeof(EmptyRequestModel))
             {
-                return (TResponse)(object )new EmptyRequestModel();
+                return (TResponse)(object)new EmptyRequestModel();
             }
             var data = JsonConvert.DeserializeObject<TResponse>(str);
 
@@ -153,7 +153,7 @@ namespace BTCPayServer.Lightning.LNbank
 
         internal class LNbankApiException : Exception
         {
-            public ErrorData Error { get; set; }
+            private ErrorData Error { get; set; }
 
             public override string Message => Error?.Detail;
             public string ErrorCode => Error?.Code;

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -6,17 +6,16 @@ namespace BTCPayServer.Lightning.LNbank
 {
     public class LNbankClient
     {
-        private readonly Uri _address;
-        private readonly string _apiToken;
-        private readonly Network _network;
+        private readonly string _walletId;
         private readonly HttpClient _httpClient;
+        private readonly JsonSerializer _serializer;
+        private readonly Network _network;
 
-        public LNbankClient(Uri address, string apiToken, Network network, HttpClient httpClient = null)
+        public LNbankClient(Uri baseUri, string apiToken, string walletId, Network network, HttpClient httpClient)
         {
-            _address = address;
-            _apiToken = apiToken;
-            _network = network;
+            _walletId = walletId;
             _httpClient = httpClient;
+            _network = network;
         }
     }
 }

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net.Http;
+using NBitcoin;
+
+namespace BTCPayServer.Lightning.LNbank
+{
+    public class LNbankClient
+    {
+        private readonly Uri _address;
+        private readonly string _apiToken;
+        private readonly Network _network;
+        private readonly HttpClient _httpClient;
+
+        public LNbankClient(Uri address, string apiToken, Network network, HttpClient httpClient = null)
+        {
+            _address = address;
+            _apiToken = apiToken;
+            _network = network;
+            _httpClient = httpClient;
+        }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -12,7 +8,6 @@ using BTCPayServer.Lightning.LNbank.Models;
 using Newtonsoft.Json;
 using NBitcoin;
 using NBitcoin.JsonConverters;
-using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Lightning.LNbank
 {
@@ -94,6 +89,15 @@ namespace BTCPayServer.Lightning.LNbank
                 FeeRate = feeRate
             };
             return await Post<CreateChannelRequest, OpenChannelResponse>("channels", payload, cancellation);
+        }
+
+        public async Task ConnectTo(NodeInfo nodeInfo, CancellationToken cancellation = default)
+        {
+            var payload = new ConnectNodeRequest
+            {
+                NodeURI = nodeInfo.ToString()
+            };
+            await Post<ConnectNodeRequest, string>("connect", payload, cancellation);
         }
 
         private async Task<TResponse> Get<TResponse>(string path, CancellationToken cancellation)

--- a/src/BTCPayServer.Lightning.LNbank/LNbankHubClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankHubClient.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+using BTCPayServer.Lightning.LNbank.Models;
+using Microsoft.AspNetCore.SignalR.Client;
+using Newtonsoft.Json.Linq;
+
+namespace BTCPayServer.Lightning.LNbank
+{
+    public class LNbankHubClient: ILightningInvoiceListener
+    {
+        private readonly LNbankLightningClient _lightningClient;
+        private readonly HubConnection _connection;
+        private readonly CancellationToken _cancellationToken;
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private LightningInvoice _invoice;
+
+        public LNbankHubClient(Uri baseUri, string apiToken, LNbankLightningClient lightningClient, CancellationToken cancellation)
+        {
+            _lightningClient = lightningClient;
+            _cancellationToken = cancellation;
+            _connection = new HubConnectionBuilder()
+                .WithUrl($"{baseUri.AbsoluteUri}Hubs/Transaction", options => {
+                    options.AccessTokenProvider = () => Task.FromResult(apiToken);
+                })
+                .WithAutomaticReconnect()
+                .Build();
+        }
+
+        public async Task SetupAsync(CancellationToken cancellation)
+        {
+            _connection.On<TransactionUpdateEvent>("transaction-update", async data =>
+            {
+                _invoice = await _lightningClient.GetInvoice(data.InvoiceId, cancellation);
+            });
+
+            await _connection.StartAsync(_cancellationToken);
+        }
+
+        public async Task<LightningInvoice> WaitInvoice(CancellationToken cancellation)
+        {
+            try
+            {
+                while (_invoice == null && !cancellation.IsCancellationRequested) {}
+                return _invoice;
+            }
+            catch (Exception) when (_cts.IsCancellationRequested)
+            {
+                throw new OperationCanceledException(_cts.Token);
+            }
+        }
+
+        public async void Dispose()
+        {
+            await DisposeAsync();
+        }
+
+        private async Task DisposeAsync()
+        {
+            await _connection.StopAsync(_cancellationToken);
+            await _connection.DisposeAsync();
+            _cts.Cancel();
+        }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -127,9 +127,23 @@ namespace BTCPayServer.Lightning.LNbank
             return new OpenChannelResponse(result);
         }
 
-        public Task<ConnectionResult> ConnectTo(NodeInfo nodeInfo)
+        public async Task<ConnectionResult> ConnectTo(NodeInfo nodeInfo)
         {
-            throw new NotImplementedException();
+            try
+            {
+                await _client.ConnectTo(nodeInfo);
+                return ConnectionResult.Ok;
+            }
+            catch (LNbankClient.LNbankApiException ex)
+            {
+                switch (ex.ErrorCode)
+                {
+                    case "could-not-connect":
+                        return ConnectionResult.CouldNotConnect;
+                    default:
+                        throw new NotSupportedException("Unknown ConnectionResult");
+                }
+            }
         }
 
         public async Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default)

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -15,11 +15,11 @@ namespace BTCPayServer.Lightning.LNbank
         private readonly Uri _baseUri;
         private readonly string _apiToken;
 
-        public LNbankLightningClient(Uri baseUri, string apiToken, string walletId, Network network, HttpClient httpClient = null)
+        public LNbankLightningClient(Uri baseUri, string apiToken, Network network, HttpClient httpClient = null)
         {
             _baseUri = baseUri;
             _apiToken = apiToken;
-            _client = new LNbankClient(baseUri, apiToken, walletId, network, httpClient);
+            _client = new LNbankClient(baseUri, apiToken, network, httpClient);
         }
 
         public async Task<LightningNodeInformation> GetInfo(CancellationToken cancellation = default)
@@ -58,6 +58,11 @@ namespace BTCPayServer.Lightning.LNbank
         public async Task<BitcoinAddress> GetDepositAddress()
         {
             return await _client.GetDepositAddress();
+        }
+
+        public async Task CancelInvoice(string invoiceId)
+        {
+            await _client.CancelInvoice(invoiceId, CancellationToken.None);
         }
 
         public async Task<LightningChannel[]> ListChannels(CancellationToken cancellation = default)

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -156,7 +156,7 @@ namespace BTCPayServer.Lightning.LNbank
         {
             var listener = new LNbankHubClient(_baseUri, _apiToken, this, cancellation);
 
-            await listener.SetupAsync(cancellation);
+            await listener.Start(cancellation);
 
             return listener;
         }

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+
+namespace BTCPayServer.Lightning.LNbank
+{
+    public class LNbankLightningClient : ILightningClient
+    {
+        private readonly Uri _address;
+        private readonly string _apiToken;
+        private readonly Network _network;
+        private readonly LNbankClient _lnbankClient;
+
+        public LNbankLightningClient(Uri address, string apiToken, Network network, HttpClient httpClient = null)
+        {
+            if (address == null)
+                throw new ArgumentNullException(nameof(address));
+            if (network == null)
+                throw new ArgumentNullException(nameof(network));
+            _address = address;
+            _network = network;
+            _apiToken = apiToken;
+            _lnbankClient = new LNbankClient(address, apiToken, network, httpClient);
+        }
+
+        public Task<LightningInvoice> GetInvoice(string invoiceId, CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<LightningInvoice> CreateInvoice(LightMoney amount, string description, TimeSpan expiry,
+            CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest,
+            CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<LightningNodeInformation> GetInfo(CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<OpenChannelResponse> OpenChannel(OpenChannelRequest openChannelRequest, CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<BitcoinAddress> GetDepositAddress()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ConnectionResult> ConnectTo(NodeInfo nodeInfo)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<LightningChannel[]> ListChannels(CancellationToken cancellation = default(CancellationToken))
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -1,18 +1,24 @@
 ﻿using System;
 using System.Linq;
 using System.Net.Http;
+using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
+using Microsoft.AspNetCore.SignalR.Client;
 
 namespace BTCPayServer.Lightning.LNbank
 {
     public class LNbankLightningClient : ILightningClient
     {
         private readonly LNbankClient _client;
+        private readonly Uri _baseUri;
+        private readonly string _apiToken;
 
         public LNbankLightningClient(Uri baseUri, string apiToken, string walletId, Network network, HttpClient httpClient = null)
         {
+            _baseUri = baseUri;
+            _apiToken = apiToken;
             _client = new LNbankClient(baseUri, apiToken, walletId, network, httpClient);
         }
 
@@ -148,7 +154,11 @@ namespace BTCPayServer.Lightning.LNbank
 
         public async Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default)
         {
-            throw new NotImplementedException();
+            var listener = new LNbankHubClient(_baseUri, _apiToken, this, cancellation);
+
+            await listener.SetupAsync(cancellation);
+
+            return listener;
         }
     }
 }

--- a/src/BTCPayServer.Lightning.LNbank/Models/ChannelData.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/ChannelData.cs
@@ -1,0 +1,22 @@
+using BTCPayServer.Lightning.JsonConverters;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class ChannelData
+    {
+        public string RemoteNode { get; set; }
+
+        public bool IsPublic { get; set; }
+
+        public bool IsActive { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney Capacity { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney LocalBalance { get; set; }
+
+        public string ChannelPoint { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/ConnectNodeRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/ConnectNodeRequest.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class ConnectNodeRequest
+    {
+        [JsonProperty("nodeURI")]
+        public string NodeURI { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/CreateChannelRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/CreateChannelRequest.cs
@@ -1,0 +1,18 @@
+using NBitcoin;
+using NBitcoin.JsonConverters;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class CreateChannelRequest
+    {
+        [JsonProperty("nodeURI")]
+        public string NodeURI { get; set; }
+
+        [JsonConverter(typeof(MoneyJsonConverter))]
+        public Money ChannelAmount { get; set; }
+
+        [JsonConverter(typeof(FeeRateJsonConverter))]
+        public FeeRate FeeRate { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/CreateInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/CreateInvoiceRequest.cs
@@ -6,8 +6,6 @@ namespace BTCPayServer.Lightning.LNbank.Models
 {
     public class CreateInvoiceRequest
     {
-        public string WalletId { get; set; }
-
         public string Description { get; set; }
 
         [JsonConverter(typeof(LightMoneyJsonConverter))]

--- a/src/BTCPayServer.Lightning.LNbank/Models/CreateInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/CreateInvoiceRequest.cs
@@ -1,0 +1,18 @@
+using System;
+using BTCPayServer.Lightning.JsonConverters;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class CreateInvoiceRequest
+    {
+        public string WalletId { get; set; }
+
+        public string Description { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney Amount { get; set; }
+
+        public TimeSpan Expiry { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/ErrorData.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/ErrorData.cs
@@ -1,0 +1,14 @@
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class ErrorData
+    {
+        public int Status { get; set; }
+        public string Title { get; set; }
+        public string Detail { get; set; }
+
+        [JsonProperty("errorCode")]
+        public string Code { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/InvoiceData.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/InvoiceData.cs
@@ -1,0 +1,30 @@
+using System;
+using BTCPayServer.Lightning.JsonConverters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class InvoiceData
+    {
+        public string Id { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LightningInvoiceStatus Status { get; set; }
+
+        [JsonProperty("BOLT11")]
+        public string BOLT11 { get; set; }
+
+        [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+        public DateTimeOffset? PaidAt { get; set; }
+
+        [JsonConverter(typeof(NBitcoin.JsonConverters.DateTimeToUnixTimeConverter))]
+        public DateTimeOffset ExpiresAt { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney Amount { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney AmountReceived { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/NodeInfoData.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/NodeInfoData.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class NodeInfoData
+    {
+        public int BlockHeight { get; set; }
+
+        [JsonProperty("nodeURIs")]
+        public List<string> NodeURIs { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/PayInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/PayInvoiceRequest.cs
@@ -2,8 +2,6 @@ namespace BTCPayServer.Lightning.LNbank.Models
 {
     public class PayInvoiceRequest
     {
-        public string WalletId { get; set; }
-
         public string PaymentRequest { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.LNbank/Models/PayInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/PayInvoiceRequest.cs
@@ -1,0 +1,9 @@
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class PayInvoiceRequest
+    {
+        public string WalletId { get; set; }
+
+        public string PaymentRequest { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/TransactionUpdateEvent.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/TransactionUpdateEvent.cs
@@ -1,0 +1,13 @@
+namespace BTCPayServer.Lightning.LNbank.Models
+{
+    public class TransactionUpdateEvent
+    {
+        public string TransactionId { get; set; }
+        public string InvoiceId { get; set; }
+        public string WalletId { get; set; }
+        public string Status { get; set; }
+        public string Event { get; set; }
+        public bool IsPaid { get; set; }
+        public bool IsExpired { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/Models/TransactionUpdateEvent.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/TransactionUpdateEvent.cs
@@ -4,7 +4,6 @@ namespace BTCPayServer.Lightning.LNbank.Models
     {
         public string TransactionId { get; set; }
         public string InvoiceId { get; set; }
-        public string WalletId { get; set; }
         public string Status { get; set; }
         public string Event { get; set; }
         public bool IsPaid { get; set; }

--- a/src/BTCPayServer.Lightning.LNbank/PushNuget.ps1
+++ b/src/BTCPayServer.Lightning.LNbank/PushNuget.ps1
@@ -1,0 +1,7 @@
+Remove-Item "bin\release\" -Recurse -Force
+dotnet pack --configuration Release --include-symbols -p:SymbolPackageFormat=snupkg
+$package=(ls .\bin\Release\*.nupkg).FullName
+dotnet nuget push $package --source "https://api.nuget.org/v3/index.json"
+$ver = ((Get-ChildItem .\bin\release\*.nupkg)[0].Name -replace '[^\d]*\.(\d+(\.\d+){1,4}).*', '$1')
+git tag -a "LNBank/v$ver" -m "LNBank/$ver"
+git push --tags

--- a/src/PushNuget.ps1
+++ b/src/PushNuget.ps1
@@ -22,6 +22,10 @@ cd BTCPayServer.Lightning.Ptarmigan
 .\PushNuget.ps1
 cd ..
 
+cd BTCPayServer.Lightning.LNbank
+.\PushNuget.ps1
+cd ..
+
 cd BTCPayServer.Lightning.All
 .\PushNuget.ps1
 cd ..

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -653,7 +653,7 @@ namespace BTCPayServer.Lightning.Tests
 			Assert.True(LightningConnectionString.TryParse("type=charge;server=http://api-token:foiewnccewuify@127.0.0.1:54938/;allowinsecure=true", out conn));
 			Assert.Equal("type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify;allowinsecure=true", conn.ToString());
 
-			Assert.True(LightningConnectionString.TryParse("type=lnbank;server=https://mybtcpay.com/lnbank;api-token=myapitoken;wallet-id=MY-LNBANK-WALLET-ID", false, out conn));
+			Assert.True(LightningConnectionString.TryParse("type=lnbank;server=https://mybtcpay.com/;api-token=myapitoken", false, out conn));
 		}
 	}
 }

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -652,6 +652,8 @@ namespace BTCPayServer.Lightning.Tests
 
 			Assert.True(LightningConnectionString.TryParse("type=charge;server=http://api-token:foiewnccewuify@127.0.0.1:54938/;allowinsecure=true", out conn));
 			Assert.Equal("type=charge;server=http://127.0.0.1:54938/;api-token=foiewnccewuify;allowinsecure=true", conn.ToString());
+
+			Assert.True(LightningConnectionString.TryParse("type=lnbank;server=https://mybtcpay.com/lnbank;api-token=myapitoken;wallet-id=MY-LNBANK-WALLET-ID", false, out conn));
 		}
 	}
 }


### PR DESCRIPTION
Adds the LNbank client, so that LNbank wallets can be used as a Lightning node/backend in BTCPay Server. 

See [details on the integration](https://github.com/dennisreimann/btcpayserver-lnbank#btcpay-server-integration).