### PR TITLE
Adding support for PaymentSecret in BOLT11 parser

### DIFF
--- a/src/BTCPayServer.Lightning.Common/BOLT11PaymentRequest.cs
+++ b/src/BTCPayServer.Lightning.Common/BOLT11PaymentRequest.cs
@@ -188,6 +188,13 @@ namespace BTCPayServer.Lightning
                         {
                         }
                         break;
+                    case 16:
+                        if (size != 52 * 5)
+                            break;
+                        if (PaymentSecret != null)
+                            throw new FormatException("Invalid BOLT11: Duplicate 's'");
+                        PaymentSecret = new uint256(reader.ReadBytes(32), false);
+                        break;
                     case 19:
                         if (size != 53 * 5)
                             break;
@@ -313,6 +320,7 @@ namespace BTCPayServer.Lightning
         public string ShortDescription { get; }
         public uint256 DescriptionHash { get; set; }
         public uint256 PaymentHash { get; }
+        public uint256 PaymentSecret { get; }
         public DateTimeOffset ExpiryDate { get; }
 
         public static bool TryParse(string str, out BOLT11PaymentRequest result, Network network)


### PR DESCRIPTION
LND 0.12 will start rejecting payments that don't include address by default. Any developer using our Lightning library will need `uint256 PaymentSecret` expose to comply with this requirement.

More details on: 
https://github.com/lightningnetwork/lnd/pull/4752