### PR TITLE
Add payment details

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/CLightningPayResponse.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningPayResponse.cs
@@ -1,0 +1,25 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.CLightning
+{
+    public class CLightningPayResponse
+    {
+        public string Destination { get; set; }
+
+        public string Status { get; set; }
+        public int Parts { get; set; }
+
+        [JsonConverter(typeof(NBitcoin.JsonConverters.UInt256JsonConverter))]
+        [JsonProperty("payment_hash")]
+        public uint256 PaymentHash { get; set; }
+
+        [JsonProperty("msatoshi")]
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
+        public LightMoney Amount { get; set; }
+
+        [JsonProperty("msatoshi_sent")]
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
+        public LightMoney AmountSent { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.Common/PayResponse.cs
+++ b/src/BTCPayServer.Lightning.Common/PayResponse.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace BTCPayServer.Lightning
+﻿namespace BTCPayServer.Lightning
 {
     public enum PayResult
     {
@@ -10,19 +6,34 @@ namespace BTCPayServer.Lightning
         CouldNotFindRoute,
         Error
     }
+
     public class PayResponse
     {
         public PayResponse(PayResult result)
         {
             Result = result;
         }
+
         public PayResponse(PayResult result, string errorDetail)
         {
             Result = result;
             ErrorDetail = errorDetail;
         }
 
+        public PayResponse(PayResult result, PayDetails details)
+        {
+            Result = result;
+            Details = details;
+        }
+
         public PayResult Result { get; set; }
+        public PayDetails Details { get; set; }
         public string ErrorDetail { get; set; }
+    }
+
+    public class PayDetails
+    {
+        public LightMoney TotalAmount { get; set; }
+        public LightMoney FeeAmount { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.Eclair/EclairClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairClient.cs
@@ -335,8 +335,6 @@ namespace BTCPayServer.Lightning.Eclair
 
 		private async Task<TResponse> SendCommandAsync<TRequest, TResponse>(string method, TRequest data, CancellationToken cts)
 		{
-
-
 			HttpContent content = null;
 			if (data != null && !(data is NoRequestModel))
 			{
@@ -353,7 +351,7 @@ namespace BTCPayServer.Lightning.Eclair
 				content = new FormUrlEncodedContent(x.Select(pair => pair));
 			}
 
-			var httpRequest = new HttpRequestMessage()
+			var httpRequest = new HttpRequestMessage
 			{
 				Method = HttpMethod.Post,
 				RequestUri = new Uri(_address, method),

--- a/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
@@ -45,7 +45,7 @@ namespace BTCPayServer.Lightning.Eclair
             {
                 return null;
             }
-            
+
             GetReceivedInfoResponse info = null;
             try
             {
@@ -143,10 +143,15 @@ namespace BTCPayServer.Lightning.Eclair
                         continue;
                     }
 
-                    switch (status.First().Status.type)
+                    var sentInfo = status.First();
+                    switch (sentInfo.Status.type)
                     {
                         case "sent":
-                            return new PayResponse(PayResult.Ok);
+                            return new PayResponse(PayResult.Ok, new PayDetails
+                                {
+                                    TotalAmount = sentInfo.Amount,
+                                    FeeAmount = sentInfo.FeesPaid
+                                });
                         case "failed":
                             return new PayResponse(PayResult.CouldNotFindRoute);
                         case "pending":

--- a/src/BTCPayServer.Lightning.Eclair/Models/GetSentInfoRequest.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/GetSentInfoRequest.cs
@@ -2,7 +2,6 @@ namespace BTCPayServer.Lightning.Eclair.Models
 {
     public class GetSentInfoRequest
     {
-            
         public string PaymentHash { get; set; }
         public string Id { get; set; }
     }

--- a/src/BTCPayServer.Lightning.Eclair/Models/GetSentInfoResponse.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/GetSentInfoResponse.cs
@@ -1,15 +1,31 @@
 using System;
+using BTCPayServer.Lightning.JsonConverters;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Lightning.Eclair.Models
 {
     public partial class GetSentInfoResponse
     {
         public Guid Id { get; set; }
+        public Guid ParentId { get; set; }
+
         public string PaymentHash { get; set; }
+        public string PaymentType { get; set; }
+        public string RecipientNodeId { get; set; }
         public string Preimage { get; set; }
         public long AmountMsat { get; set; }
         public long CreatedAt { get; set; }
         public long CompletedAt { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney RecipientAmount { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney Amount { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public long FeesPaid { get; set; }
+
         public PaymentStatus Status { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.LND/LndSwaggerClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndSwaggerClient.cs
@@ -12,24 +12,24 @@ namespace BTCPayServer.Lightning.LND
     #pragma warning disable // Disable all warnings
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "11.11.1.0")]
-     partial class LndSwaggerClient 
+     partial class LndSwaggerClient
     {
         private System.Lazy<Newtonsoft.Json.JsonSerializerSettings> _settings;
         private string _baseUrl = "";
-        
-        private System.Net.Http.HttpClient _httpClient;     
-    
-        public string BaseUrl 
+
+        private System.Net.Http.HttpClient _httpClient;
+
+        public string BaseUrl
         {
             get { return _baseUrl; }
             set { _baseUrl = value; }
         }
-    
+
         partial void UpdateJsonSerializerSettings(Newtonsoft.Json.JsonSerializerSettings settings);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
         partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
         partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
-    
+
         /// <summary>* lncli: `walletbalance`
         /// WalletBalance returns total unspent outputs(confirmed and unconfirmed), all
         /// confirmed unspent outputs and all unconfirmed unspent outputs under control
@@ -39,7 +39,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return WalletBalanceAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `walletbalance`
         /// WalletBalance returns total unspent outputs(confirmed and unconfirmed), all
         /// confirmed unspent outputs and all unconfirmed unspent outputs under control
@@ -50,7 +50,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/balance/blockchain");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -58,32 +58,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcWalletBalanceResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcWalletBalanceResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcWalletBalanceResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -91,10 +91,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcWalletBalanceResponse);
                     }
                     finally
@@ -108,7 +108,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `channelbalance`
         /// ChannelBalance returns the total funds available across all open channels
         /// in satoshis.</summary>
@@ -117,7 +117,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return ChannelBalanceAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `channelbalance`
         /// ChannelBalance returns the total funds available across all open channels
         /// in satoshis.</summary>
@@ -127,7 +127,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/balance/channels");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -135,32 +135,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcChannelBalanceResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcChannelBalanceResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelBalanceResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -168,10 +168,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcChannelBalanceResponse);
                     }
                     finally
@@ -185,7 +185,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `listchannels`
         /// ListChannels returns a description of all the open channels that this node
         /// is a participant in.</summary>
@@ -194,7 +194,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return ListChannelsAsync(active_only, inactive_only, public_only, private_only, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `listchannels`
         /// ListChannels returns a description of all the open channels that this node
         /// is a participant in.</summary>
@@ -209,7 +209,7 @@ namespace BTCPayServer.Lightning.LND
             if (public_only != null) urlBuilder_.Append("public_only=").Append(System.Uri.EscapeDataString(System.Convert.ToString(public_only.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             if (private_only != null) urlBuilder_.Append("private_only=").Append(System.Uri.EscapeDataString(System.Convert.ToString(private_only.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             urlBuilder_.Length--;
-    
+
             var client_ = _httpClient;
             try
             {
@@ -217,32 +217,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcListChannelsResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcListChannelsResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListChannelsResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -250,10 +250,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcListChannelsResponse);
                     }
                     finally
@@ -267,7 +267,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>*
         /// OpenChannelSync is a synchronous version of the OpenChannel RPC call. This
         /// call is meant to be consumed by clients to the REST proxy. As with all
@@ -278,7 +278,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return OpenChannelSyncAsync(body, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>*
         /// OpenChannelSync is a synchronous version of the OpenChannel RPC call. This
         /// call is meant to be consumed by clients to the REST proxy. As with all
@@ -290,7 +290,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/channels");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -301,32 +301,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcChannelPoint); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcChannelPoint);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelPoint>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -334,10 +334,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcChannelPoint);
                     }
                     finally
@@ -351,7 +351,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `pendingchannels`
         /// PendingChannels returns a list of all the channels that are currently
         /// considered "pending". A channel is pending if it has finished the funding
@@ -362,7 +362,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return PendingChannelsAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `pendingchannels`
         /// PendingChannels returns a list of all the channels that are currently
         /// considered "pending". A channel is pending if it has finished the funding
@@ -374,7 +374,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/channels/pending");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -382,32 +382,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcPendingChannelsResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcPendingChannelsResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPendingChannelsResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -415,10 +415,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcPendingChannelsResponse);
                     }
                     finally
@@ -432,7 +432,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>*
         /// SendPaymentSync is the synchronous non-streaming version of SendPayment.
         /// This RPC is intended to be consumed by clients of the REST proxy.
@@ -443,7 +443,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return SendPaymentSyncAsync(body, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>*
         /// SendPaymentSync is the synchronous non-streaming version of SendPayment.
         /// This RPC is intended to be consumed by clients of the REST proxy.
@@ -455,7 +455,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/channels/transactions");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -466,32 +466,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcSendResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcSendResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSendResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -499,10 +499,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcSendResponse);
                     }
                     finally
@@ -516,7 +516,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `closechannel`
         /// CloseChannel attempts to close an active channel identified by its channel
         /// outpoint (ChannelPoint). The actions of this method can additionally be
@@ -531,7 +531,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return CloseChannelAsync(channel_point_funding_txid_str, channel_point_output_index, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `closechannel`
         /// CloseChannel attempts to close an active channel identified by its channel
         /// outpoint (ChannelPoint). The actions of this method can additionally be
@@ -547,15 +547,15 @@ namespace BTCPayServer.Lightning.LND
         {
             if (channel_point_funding_txid_str == null)
                 throw new System.ArgumentNullException("channel_point_funding_txid_str");
-    
+
             if (channel_point_output_index == null)
                 throw new System.ArgumentNullException("channel_point_output_index");
-    
+
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/channels/{channel_point.funding_txid_str}/{channel_point.output_index}");
             urlBuilder_.Replace("{channel_point.funding_txid_str}", System.Uri.EscapeDataString(System.Convert.ToString(channel_point_funding_txid_str, System.Globalization.CultureInfo.InvariantCulture)));
             urlBuilder_.Replace("{channel_point.output_index}", System.Uri.EscapeDataString(System.Convert.ToString(channel_point_output_index, System.Globalization.CultureInfo.InvariantCulture)));
-    
+
             var client_ = _httpClient;
             try
             {
@@ -563,32 +563,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("DELETE");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcCloseStatusUpdate); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcCloseStatusUpdate);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcCloseStatusUpdate>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -596,10 +596,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcCloseStatusUpdate);
                     }
                     finally
@@ -613,7 +613,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `updatechanpolicy`
         /// UpdateChannelPolicy allows the caller to update the fee schedule and
         /// channel policies for all channels globally, or a particular channel.</summary>
@@ -622,7 +622,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return UpdateChannelPolicyAsync(body, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `updatechanpolicy`
         /// UpdateChannelPolicy allows the caller to update the fee schedule and
         /// channel policies for all channels globally, or a particular channel.</summary>
@@ -632,7 +632,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/chanpolicy");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -643,32 +643,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(object); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(object);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<object>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -676,10 +676,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(object);
                     }
                     finally
@@ -693,7 +693,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `feereport`
         /// FeeReport allows the caller to obtain a report detailing the current fee
         /// schedule enforced by the node globally for each channel.</summary>
@@ -702,7 +702,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return FeeReportAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `feereport`
         /// FeeReport allows the caller to obtain a report detailing the current fee
         /// schedule enforced by the node globally for each channel.</summary>
@@ -712,7 +712,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/fees");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -720,32 +720,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcFeeReportResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcFeeReportResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcFeeReportResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -753,10 +753,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcFeeReportResponse);
                     }
                     finally
@@ -770,7 +770,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>*
         /// GenSeed is the first method that should be used to instantiate a new lnd
         /// instance. This method allows a caller to generate a new aezeed cipher seed
@@ -787,7 +787,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return GenSeedAsync(aezeed_passphrase, seed_entropy, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>*
         /// GenSeed is the first method that should be used to instantiate a new lnd
         /// instance. This method allows a caller to generate a new aezeed cipher seed
@@ -808,7 +808,7 @@ namespace BTCPayServer.Lightning.LND
             if (aezeed_passphrase != null) urlBuilder_.Append("aezeed_passphrase=").Append(System.Uri.EscapeDataString(System.Convert.ToString(aezeed_passphrase, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             if (seed_entropy != null) urlBuilder_.Append("seed_entropy=").Append(System.Uri.EscapeDataString(System.Convert.ToString(seed_entropy, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             urlBuilder_.Length--;
-    
+
             var client_ = _httpClient;
             try
             {
@@ -816,32 +816,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcGenSeedResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcGenSeedResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcGenSeedResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -849,10 +849,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcGenSeedResponse);
                     }
                     finally
@@ -866,7 +866,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `getinfo`
         /// GetInfo returns general information concerning the lightning node including
         /// it's identity pubkey, alias, the chains it is connected to, and information
@@ -876,7 +876,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return GetInfoAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `getinfo`
         /// GetInfo returns general information concerning the lightning node including
         /// it's identity pubkey, alias, the chains it is connected to, and information
@@ -887,7 +887,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/getinfo");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -895,32 +895,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcGetInfoResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcGetInfoResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcGetInfoResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -928,10 +928,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcGetInfoResponse);
                     }
                     finally
@@ -945,7 +945,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `describegraph`
         /// DescribeGraph returns a description of the latest graph state from the
         /// point of view of the node. The graph information is partitioned into two
@@ -958,7 +958,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return DescribeGraphAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `describegraph`
         /// DescribeGraph returns a description of the latest graph state from the
         /// point of view of the node. The graph information is partitioned into two
@@ -972,7 +972,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/graph");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -980,32 +980,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcChannelGraph); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcChannelGraph);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelGraph>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1013,10 +1013,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcChannelGraph);
                     }
                     finally
@@ -1030,7 +1030,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `getchaninfo`
         /// GetChanInfo returns the latest authenticated network announcement for the
         /// given channel identified by its channel ID: an 8-byte integer which
@@ -1041,7 +1041,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return GetChanInfoAsync(chan_id, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `getchaninfo`
         /// GetChanInfo returns the latest authenticated network announcement for the
         /// given channel identified by its channel ID: an 8-byte integer which
@@ -1053,11 +1053,11 @@ namespace BTCPayServer.Lightning.LND
         {
             if (chan_id == null)
                 throw new System.ArgumentNullException("chan_id");
-    
+
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/graph/edge/{chan_id}");
             urlBuilder_.Replace("{chan_id}", System.Uri.EscapeDataString(System.Convert.ToString(chan_id, System.Globalization.CultureInfo.InvariantCulture)));
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1065,32 +1065,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcChannelEdge); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcChannelEdge);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelEdge>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1098,10 +1098,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcChannelEdge);
                     }
                     finally
@@ -1115,7 +1115,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `getnetworkinfo`
         /// GetNetworkInfo returns some basic stats about the known channel graph from
         /// the point of view of the node.</summary>
@@ -1124,7 +1124,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return GetNetworkInfoAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `getnetworkinfo`
         /// GetNetworkInfo returns some basic stats about the known channel graph from
         /// the point of view of the node.</summary>
@@ -1134,7 +1134,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/graph/info");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1142,32 +1142,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcNetworkInfo); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcNetworkInfo);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNetworkInfo>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1175,10 +1175,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcNetworkInfo);
                     }
                     finally
@@ -1192,7 +1192,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `getnodeinfo`
         /// GetNodeInfo returns the latest advertised, aggregated, and authenticated
         /// channel information for the specified node identified by its public key.</summary>
@@ -1201,7 +1201,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return GetNodeInfoAsync(pub_key, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `getnodeinfo`
         /// GetNodeInfo returns the latest advertised, aggregated, and authenticated
         /// channel information for the specified node identified by its public key.</summary>
@@ -1211,11 +1211,11 @@ namespace BTCPayServer.Lightning.LND
         {
             if (pub_key == null)
                 throw new System.ArgumentNullException("pub_key");
-    
+
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/graph/node/{pub_key}");
             urlBuilder_.Replace("{pub_key}", System.Uri.EscapeDataString(System.Convert.ToString(pub_key, System.Globalization.CultureInfo.InvariantCulture)));
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1223,32 +1223,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcNodeInfo); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcNodeInfo);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNodeInfo>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1256,10 +1256,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcNodeInfo);
                     }
                     finally
@@ -1273,7 +1273,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `queryroutes`
         /// QueryRoutes attempts to query the daemon's Channel Router for a possible
         /// route to a target destination capable of carrying a specific amount of
@@ -1286,7 +1286,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return QueryRoutesAsync(pub_key, amt, num_routes, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `queryroutes`
         /// QueryRoutes attempts to query the daemon's Channel Router for a possible
         /// route to a target destination capable of carrying a specific amount of
@@ -1300,17 +1300,17 @@ namespace BTCPayServer.Lightning.LND
         {
             if (pub_key == null)
                 throw new System.ArgumentNullException("pub_key");
-    
+
             if (amt == null)
                 throw new System.ArgumentNullException("amt");
-    
+
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/graph/routes/{pub_key}/{amt}?");
             urlBuilder_.Replace("{pub_key}", System.Uri.EscapeDataString(System.Convert.ToString(pub_key, System.Globalization.CultureInfo.InvariantCulture)));
             urlBuilder_.Replace("{amt}", System.Uri.EscapeDataString(System.Convert.ToString(amt, System.Globalization.CultureInfo.InvariantCulture)));
             if (num_routes != null) urlBuilder_.Append("num_routes=").Append(System.Uri.EscapeDataString(System.Convert.ToString(num_routes.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             urlBuilder_.Length--;
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1318,32 +1318,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcQueryRoutesResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcQueryRoutesResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcQueryRoutesResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1351,10 +1351,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcQueryRoutesResponse);
                     }
                     finally
@@ -1368,8 +1368,8 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
-        /// <summary>* 
+
+        /// <summary>*
         /// InitWallet is used when lnd is starting up for the first time to fully
         /// initialize the daemon and its internal wallet. At the very least a wallet
         /// password must be provided. This will be used to encrypt sensitive material
@@ -1379,8 +1379,8 @@ namespace BTCPayServer.Lightning.LND
         {
             return InitWalletAsync(body, System.Threading.CancellationToken.None);
         }
-    
-        /// <summary>* 
+
+        /// <summary>*
         /// InitWallet is used when lnd is starting up for the first time to fully
         /// initialize the daemon and its internal wallet. At the very least a wallet
         /// password must be provided. This will be used to encrypt sensitive material
@@ -1391,7 +1391,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/initwallet");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1402,32 +1402,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(object); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(object);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<object>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1435,10 +1435,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(object);
                     }
                     finally
@@ -1452,7 +1452,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `lookupinvoice`
         /// LookupInvoice attempts to look up an invoice according to its payment hash.
         /// The passed payment hash *must* be exactly 32 bytes, if not, an error is
@@ -1463,7 +1463,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return LookupInvoiceAsync(r_hash_str, r_hash, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `lookupinvoice`
         /// LookupInvoice attempts to look up an invoice according to its payment hash.
         /// The passed payment hash *must* be exactly 32 bytes, if not, an error is
@@ -1475,13 +1475,13 @@ namespace BTCPayServer.Lightning.LND
         {
             if (r_hash_str == null)
                 throw new System.ArgumentNullException("r_hash_str");
-    
+
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/invoice/{r_hash_str}?");
             urlBuilder_.Replace("{r_hash_str}", System.Uri.EscapeDataString(System.Convert.ToString(r_hash_str, System.Globalization.CultureInfo.InvariantCulture)));
             if (r_hash != null) urlBuilder_.Append("r_hash=").Append(System.Uri.EscapeDataString(System.Convert.ToString(r_hash, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             urlBuilder_.Length--;
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1489,32 +1489,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcInvoice); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcInvoice);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcInvoice>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1522,10 +1522,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcInvoice);
                     }
                     finally
@@ -1539,7 +1539,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `listinvoices`
         /// ListInvoices returns a list of all the invoices currently stored within the
         /// database. Any active debug invoices are ignored.</summary>
@@ -1549,7 +1549,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return ListInvoicesAsync(pending_only, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `listinvoices`
         /// ListInvoices returns a list of all the invoices currently stored within the
         /// database. Any active debug invoices are ignored.</summary>
@@ -1562,7 +1562,7 @@ namespace BTCPayServer.Lightning.LND
             urlBuilder_.Append(BaseUrl).Append("/v1/invoices?");
             if (pending_only != null) urlBuilder_.Append("pending_only=").Append(System.Uri.EscapeDataString(System.Convert.ToString(pending_only.Value, System.Globalization.CultureInfo.InvariantCulture))).Append("&");
             urlBuilder_.Length--;
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1570,32 +1570,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcListInvoiceResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcListInvoiceResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListInvoiceResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1603,10 +1603,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcListInvoiceResponse);
                     }
                     finally
@@ -1620,7 +1620,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `addinvoice`
         /// AddInvoice attempts to add a new invoice to the invoice database. Any
         /// duplicated invoices are rejected, therefore all invoices *must* have a
@@ -1630,7 +1630,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return AddInvoiceAsync(body, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `addinvoice`
         /// AddInvoice attempts to add a new invoice to the invoice database. Any
         /// duplicated invoices are rejected, therefore all invoices *must* have a
@@ -1641,7 +1641,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/invoices");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1652,32 +1652,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcAddInvoiceResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcAddInvoiceResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcAddInvoiceResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1685,10 +1685,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcAddInvoiceResponse);
                     }
                     finally
@@ -1702,7 +1702,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>*
         /// SubscribeInvoices returns a uni-directional stream (sever -> client) for
         /// notifying the client of newly added/settled invoices.</summary>
@@ -1712,7 +1712,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return SubscribeInvoicesAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>*
         /// SubscribeInvoices returns a uni-directional stream (sever -> client) for
         /// notifying the client of newly added/settled invoices.</summary>
@@ -1723,7 +1723,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/invoices/subscribe");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1731,32 +1731,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcInvoice); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcInvoice);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcInvoice>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1764,10 +1764,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcInvoice);
                     }
                     finally
@@ -1781,7 +1781,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>*
         /// NewWitnessAddress creates a new witness address under control of the local wallet.</summary>
         /// <exception cref="SwaggerException">A server side error occurred.</exception>
@@ -1789,7 +1789,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return NewWitnessAddressAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>*
         /// NewWitnessAddress creates a new witness address under control of the local wallet.</summary>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -1798,7 +1798,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/newaddress");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1806,32 +1806,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcNewAddressResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcNewAddressResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNewAddressResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1839,10 +1839,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcNewAddressResponse);
                     }
                     finally
@@ -1856,7 +1856,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `listpayments`
         /// ListPayments returns a list of all outgoing payments.</summary>
         /// <exception cref="SwaggerException">A server side error occurred.</exception>
@@ -1864,7 +1864,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return ListPaymentsAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `listpayments`
         /// ListPayments returns a list of all outgoing payments.</summary>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -1873,7 +1873,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/payments");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1881,32 +1881,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcListPaymentsResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcListPaymentsResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListPaymentsResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1914,10 +1914,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcListPaymentsResponse);
                     }
                     finally
@@ -1931,7 +1931,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>*
         /// DeleteAllPayments deletes all outgoing payments from DB.</summary>
         /// <exception cref="SwaggerException">A server side error occurred.</exception>
@@ -1939,7 +1939,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return DeleteAllPaymentsAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>*
         /// DeleteAllPayments deletes all outgoing payments from DB.</summary>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -1948,7 +1948,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/payments");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -1956,32 +1956,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("DELETE");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(object); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(object);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<object>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -1989,10 +1989,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(object);
                     }
                     finally
@@ -2006,7 +2006,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `decodepayreq`
         /// DecodePayReq takes an encoded payment request string and attempts to decode
         /// it, returning a full description of the conditions encoded within the
@@ -2016,7 +2016,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return DecodePayReqAsync(pay_req, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `decodepayreq`
         /// DecodePayReq takes an encoded payment request string and attempts to decode
         /// it, returning a full description of the conditions encoded within the
@@ -2027,11 +2027,11 @@ namespace BTCPayServer.Lightning.LND
         {
             if (pay_req == null)
                 throw new System.ArgumentNullException("pay_req");
-    
+
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/payreq/{pay_req}");
             urlBuilder_.Replace("{pay_req}", System.Uri.EscapeDataString(System.Convert.ToString(pay_req, System.Globalization.CultureInfo.InvariantCulture)));
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2039,32 +2039,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcPayReq); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcPayReq);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPayReq>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2072,10 +2072,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcPayReq);
                     }
                     finally
@@ -2089,7 +2089,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `listpeers`
         /// ListPeers returns a verbose listing of all currently active peers.</summary>
         /// <exception cref="SwaggerException">A server side error occurred.</exception>
@@ -2097,7 +2097,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return ListPeersAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `listpeers`
         /// ListPeers returns a verbose listing of all currently active peers.</summary>
         /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
@@ -2106,7 +2106,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/peers");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2114,32 +2114,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcListPeersResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcListPeersResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListPeersResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2147,10 +2147,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcListPeersResponse);
                     }
                     finally
@@ -2164,7 +2164,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `connect`
         /// ConnectPeer attempts to establish a connection to a remote peer. This is at
         /// the networking level, and is used for communication between nodes. This is
@@ -2187,7 +2187,7 @@ namespace BTCPayServer.Lightning.LND
                 return ConnectionResult.CouldNotConnect;
             }
         }
-    
+
         /// <summary>* lncli: `connect`
         /// ConnectPeer attempts to establish a connection to a remote peer. This is at
         /// the networking level, and is used for communication between nodes. This is
@@ -2198,7 +2198,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/peers");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2209,32 +2209,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(object); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(object);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<object>(responseData_, _settings.Value);
                                 return;
-                            } 
-                            catch (System.Exception exception) 
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2245,7 +2245,7 @@ namespace BTCPayServer.Lightning.LND
                             var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return;
                     }
                     finally
@@ -2259,7 +2259,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `disconnect`
         /// DisconnectPeer attempts to disconnect one peer from another identified by a
         /// given pubKey. In the case that we currently have a pending or active channel
@@ -2269,7 +2269,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return DisconnectPeerAsync(pub_key, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `disconnect`
         /// DisconnectPeer attempts to disconnect one peer from another identified by a
         /// given pubKey. In the case that we currently have a pending or active channel
@@ -2280,11 +2280,11 @@ namespace BTCPayServer.Lightning.LND
         {
             if (pub_key == null)
                 throw new System.ArgumentNullException("pub_key");
-    
+
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/peers/{pub_key}");
             urlBuilder_.Replace("{pub_key}", System.Uri.EscapeDataString(System.Convert.ToString(pub_key, System.Globalization.CultureInfo.InvariantCulture)));
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2292,32 +2292,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("DELETE");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(object); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(object);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<object>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2325,10 +2325,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(object);
                     }
                     finally
@@ -2342,7 +2342,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `fwdinghistory`
         /// ForwardingHistory allows the caller to query the htlcswitch for a record of
         /// all HTLC's forwarded within the target time range, and integer offset
@@ -2353,7 +2353,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return ForwardingHistoryAsync(body, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `fwdinghistory`
         /// ForwardingHistory allows the caller to query the htlcswitch for a record of
         /// all HTLC's forwarded within the target time range, and integer offset
@@ -2365,7 +2365,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/switch");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2376,32 +2376,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcForwardingHistoryResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcForwardingHistoryResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcForwardingHistoryResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2409,10 +2409,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcForwardingHistoryResponse);
                     }
                     finally
@@ -2426,7 +2426,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `listchaintxns`
         /// GetTransactions returns a list describing all the known transactions
         /// relevant to the wallet.</summary>
@@ -2435,7 +2435,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return GetTransactionsAsync(System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `listchaintxns`
         /// GetTransactions returns a list describing all the known transactions
         /// relevant to the wallet.</summary>
@@ -2445,7 +2445,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/transactions");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2453,32 +2453,32 @@ namespace BTCPayServer.Lightning.LND
                 {
                     request_.Method = new System.Net.Http.HttpMethod("GET");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcTransactionDetails); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcTransactionDetails);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcTransactionDetails>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2486,10 +2486,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcTransactionDetails);
                     }
                     finally
@@ -2503,7 +2503,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `sendcoins`
         /// SendCoins executes a request to send coins to a particular address. Unlike
         /// SendMany, this RPC call only allows creating a single output at a time. If
@@ -2515,7 +2515,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return SendCoinsAsync(body, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `sendcoins`
         /// SendCoins executes a request to send coins to a particular address. Unlike
         /// SendMany, this RPC call only allows creating a single output at a time. If
@@ -2528,7 +2528,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/transactions");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2539,32 +2539,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(LnrpcSendCoinsResponse); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(LnrpcSendCoinsResponse);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSendCoinsResponse>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2572,10 +2572,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(LnrpcSendCoinsResponse);
                     }
                     finally
@@ -2589,7 +2589,7 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
         /// <summary>* lncli: `unlock`
         /// UnlockWallet is used at startup of lnd to provide a password to unlock
         /// the wallet database.</summary>
@@ -2598,7 +2598,7 @@ namespace BTCPayServer.Lightning.LND
         {
             return UnlockWalletAsync(body, System.Threading.CancellationToken.None);
         }
-    
+
         /// <summary>* lncli: `unlock`
         /// UnlockWallet is used at startup of lnd to provide a password to unlock
         /// the wallet database.</summary>
@@ -2608,7 +2608,7 @@ namespace BTCPayServer.Lightning.LND
         {
             var urlBuilder_ = new System.Text.StringBuilder();
             urlBuilder_.Append(BaseUrl).Append("/v1/unlockwallet");
-    
+
             var client_ = _httpClient;
             try
             {
@@ -2619,32 +2619,32 @@ namespace BTCPayServer.Lightning.LND
                     request_.Content = content_;
                     request_.Method = new System.Net.Http.HttpMethod("POST");
                     request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-    
+
                     PrepareRequest(client_, request_, urlBuilder_);
                     var url_ = urlBuilder_.ToString();
                     request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
                     PrepareRequest(client_, request_, url_);
-    
+
                     var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
                     try
                     {
                         var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
                         foreach (var item_ in response_.Content.Headers)
                             headers_[item_.Key] = item_.Value;
-    
+
                         ProcessResponse(client_, response_);
-    
+
                         var status_ = ((int)response_.StatusCode).ToString();
-                        if (status_ == "200") 
+                        if (status_ == "200")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
-                            var result_ = default(object); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
+                            var result_ = default(object);
                             try
                             {
                                 result_ = Newtonsoft.Json.JsonConvert.DeserializeObject<object>(responseData_, _settings.Value);
-                                return result_; 
-                            } 
-                            catch (System.Exception exception) 
+                                return result_;
+                            }
+                            catch (System.Exception exception)
                             {
                                 throw new SwaggerException("Could not deserialize the response body.", status_, responseData_, headers_, exception);
                             }
@@ -2652,10 +2652,10 @@ namespace BTCPayServer.Lightning.LND
                         else
                         if (status_ != "200" && status_ != "204")
                         {
-                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            var responseData_ = await response_.Content.ReadAsStringAsync().ConfigureAwait(false);
                             throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", status_, responseData_, headers_, null);
                         }
-            
+
                         return default(object);
                     }
                     finally
@@ -2669,65 +2669,65 @@ namespace BTCPayServer.Lightning.LND
             {
             }
         }
-    
+
     }
-    
-    
+
+
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PendingChannelsResponseClosedChannel : System.ComponentModel.INotifyPropertyChanged
     {
         private PendingChannelsResponsePendingChannel _channel;
         private string _closing_txid;
-    
+
         [Newtonsoft.Json.JsonProperty("channel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PendingChannelsResponsePendingChannel Channel
         {
             get { return _channel; }
-            set 
+            set
             {
                 if (_channel != value)
                 {
-                    _channel = value; 
+                    _channel = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("closing_txid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Closing_txid
         {
             get { return _closing_txid; }
-            set 
+            set
             {
                 if (_closing_txid != value)
                 {
-                    _closing_txid = value; 
+                    _closing_txid = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static PendingChannelsResponseClosedChannel FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<PendingChannelsResponseClosedChannel>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PendingChannelsResponseForceClosedChannel : System.ComponentModel.INotifyPropertyChanged
     {
@@ -2738,63 +2738,63 @@ namespace BTCPayServer.Lightning.LND
         private int? _blocks_til_maturity;
         private string _recovered_balance;
         private System.Collections.ObjectModel.ObservableCollection<LnrpcPendingHTLC> _pending_htlcs;
-    
+
         [Newtonsoft.Json.JsonProperty("channel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PendingChannelsResponsePendingChannel Channel
         {
             get { return _channel; }
-            set 
+            set
             {
                 if (_channel != value)
                 {
-                    _channel = value; 
+                    _channel = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("closing_txid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Closing_txid
         {
             get { return _closing_txid; }
-            set 
+            set
             {
                 if (_closing_txid != value)
                 {
-                    _closing_txid = value; 
+                    _closing_txid = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("limbo_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Limbo_balance
         {
             get { return _limbo_balance; }
-            set 
+            set
             {
                 if (_limbo_balance != value)
                 {
-                    _limbo_balance = value; 
+                    _limbo_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("maturity_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Maturity_height
         {
             get { return _maturity_height; }
-            set 
+            set
             {
                 if (_maturity_height != value)
                 {
-                    _maturity_height = value; 
+                    _maturity_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>Remaining # of blocks until the commitment output can be swept.
         /// Negative values indicate how many blocks have passed since becoming
         /// mature.</summary>
@@ -2802,64 +2802,64 @@ namespace BTCPayServer.Lightning.LND
         public int? Blocks_til_maturity
         {
             get { return _blocks_til_maturity; }
-            set 
+            set
             {
                 if (_blocks_til_maturity != value)
                 {
-                    _blocks_til_maturity = value; 
+                    _blocks_til_maturity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("recovered_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Recovered_balance
         {
             get { return _recovered_balance; }
-            set 
+            set
             {
                 if (_recovered_balance != value)
                 {
-                    _recovered_balance = value; 
+                    _recovered_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("pending_htlcs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcPendingHTLC> Pending_htlcs
         {
             get { return _pending_htlcs; }
-            set 
+            set
             {
                 if (_pending_htlcs != value)
                 {
-                    _pending_htlcs = value; 
+                    _pending_htlcs = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static PendingChannelsResponseForceClosedChannel FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<PendingChannelsResponseForceClosedChannel>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PendingChannelsResponsePendingChannel : System.ComponentModel.INotifyPropertyChanged
     {
@@ -2868,97 +2868,97 @@ namespace BTCPayServer.Lightning.LND
         private string _capacity;
         private string _local_balance;
         private string _remote_balance;
-    
+
         [Newtonsoft.Json.JsonProperty("remote_node_pub", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Remote_node_pub
         {
             get { return _remote_node_pub; }
-            set 
+            set
             {
                 if (_remote_node_pub != value)
                 {
-                    _remote_node_pub = value; 
+                    _remote_node_pub = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("channel_point", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Channel_point
         {
             get { return _channel_point; }
-            set 
+            set
             {
                 if (_channel_point != value)
                 {
-                    _channel_point = value; 
+                    _channel_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Capacity
         {
             get { return _capacity; }
-            set 
+            set
             {
                 if (_capacity != value)
                 {
-                    _capacity = value; 
+                    _capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("local_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Local_balance
         {
             get { return _local_balance; }
-            set 
+            set
             {
                 if (_local_balance != value)
                 {
-                    _local_balance = value; 
+                    _local_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("remote_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Remote_balance
         {
             get { return _remote_balance; }
-            set 
+            set
             {
                 if (_remote_balance != value)
                 {
-                    _remote_balance = value; 
+                    _remote_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static PendingChannelsResponsePendingChannel FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<PendingChannelsResponsePendingChannel>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PendingChannelsResponsePendingOpenChannel : System.ComponentModel.INotifyPropertyChanged
     {
@@ -2967,35 +2967,35 @@ namespace BTCPayServer.Lightning.LND
         private string _commit_fee;
         private string _commit_weight;
         private string _fee_per_kw;
-    
+
         [Newtonsoft.Json.JsonProperty("channel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PendingChannelsResponsePendingChannel Channel
         {
             get { return _channel; }
-            set 
+            set
             {
                 if (_channel != value)
                 {
-                    _channel = value; 
+                    _channel = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("confirmation_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Confirmation_height
         {
             get { return _confirmation_height; }
-            set 
+            set
             {
                 if (_confirmation_height != value)
                 {
-                    _confirmation_height = value; 
+                    _confirmation_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The amount calculated to be paid in fees for the current set of
         /// commitment transactions. The fee amount is persisted with the channel
@@ -3006,30 +3006,30 @@ namespace BTCPayServer.Lightning.LND
         public string Commit_fee
         {
             get { return _commit_fee; }
-            set 
+            set
             {
                 if (_commit_fee != value)
                 {
-                    _commit_fee = value; 
+                    _commit_fee = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("commit_weight", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Commit_weight
         {
             get { return _commit_weight; }
-            set 
+            set
             {
                 if (_commit_weight != value)
                 {
-                    _commit_weight = value; 
+                    _commit_weight = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The required number of satoshis per kilo-weight that the requester will
         /// pay at all times, for both the funding transaction and commitment
@@ -3038,110 +3038,110 @@ namespace BTCPayServer.Lightning.LND
         public string Fee_per_kw
         {
             get { return _fee_per_kw; }
-            set 
+            set
             {
                 if (_fee_per_kw != value)
                 {
-                    _fee_per_kw = value; 
+                    _fee_per_kw = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static PendingChannelsResponsePendingOpenChannel FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<PendingChannelsResponsePendingOpenChannel>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class PendingChannelsResponseWaitingCloseChannel : System.ComponentModel.INotifyPropertyChanged
     {
         private PendingChannelsResponsePendingChannel _channel;
         private string _limbo_balance;
-    
+
         [Newtonsoft.Json.JsonProperty("channel", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public PendingChannelsResponsePendingChannel Channel
         {
             get { return _channel; }
-            set 
+            set
             {
                 if (_channel != value)
                 {
-                    _channel = value; 
+                    _channel = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("limbo_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Limbo_balance
         {
             get { return _limbo_balance; }
-            set 
+            set
             {
                 if (_limbo_balance != value)
                 {
-                    _limbo_balance = value; 
+                    _limbo_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static PendingChannelsResponseWaitingCloseChannel FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<PendingChannelsResponseWaitingCloseChannel>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcAddInvoiceResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private byte[] _r_hash;
         private string _payment_request;
-    
+
         [Newtonsoft.Json.JsonProperty("r_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] R_hash
         {
             get { return _r_hash; }
-            set 
+            set
             {
                 if (_r_hash != value)
                 {
-                    _r_hash = value; 
+                    _r_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// A bare-bones invoice for a payment within the Lightning Network.  With the
         /// details of the invoice, the sender has all the data necessary to send a
@@ -3150,36 +3150,36 @@ namespace BTCPayServer.Lightning.LND
         public string Payment_request
         {
             get { return _payment_request; }
-            set 
+            set
             {
                 if (_payment_request != value)
                 {
-                    _payment_request = value; 
+                    _payment_request = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcAddInvoiceResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcAddInvoiceResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannel : System.ComponentModel.INotifyPropertyChanged
     {
@@ -3200,35 +3200,35 @@ namespace BTCPayServer.Lightning.LND
         private System.Collections.ObjectModel.ObservableCollection<LnrpcHTLC> _pending_htlcs;
         private long? _csv_delay;
         private bool? _private;
-    
+
         [Newtonsoft.Json.JsonProperty("active", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Active
         {
             get { return _active; }
-            set 
+            set
             {
                 if (_active != value)
                 {
-                    _active = value; 
+                    _active = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("remote_pubkey", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Remote_pubkey
         {
             get { return _remote_pubkey; }
-            set 
+            set
             {
                 if (_remote_pubkey != value)
                 {
-                    _remote_pubkey = value; 
+                    _remote_pubkey = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The outpoint (txid:index) of the funding transaction. With this value, Bob
         /// will be able to generate a signature for Alice's version of the commitment
@@ -3237,16 +3237,16 @@ namespace BTCPayServer.Lightning.LND
         public string Channel_point
         {
             get { return _channel_point; }
-            set 
+            set
             {
                 if (_channel_point != value)
                 {
-                    _channel_point = value; 
+                    _channel_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The unique channel ID for the channel. The first 3 bytes are the block
         /// height, the next 3 the index within the block, and the last 2 bytes are the
@@ -3255,58 +3255,58 @@ namespace BTCPayServer.Lightning.LND
         public string Chan_id
         {
             get { return _chan_id; }
-            set 
+            set
             {
                 if (_chan_id != value)
                 {
-                    _chan_id = value; 
+                    _chan_id = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Capacity
         {
             get { return _capacity; }
-            set 
+            set
             {
                 if (_capacity != value)
                 {
-                    _capacity = value; 
+                    _capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("local_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Local_balance
         {
             get { return _local_balance; }
-            set 
+            set
             {
                 if (_local_balance != value)
                 {
-                    _local_balance = value; 
+                    _local_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("remote_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Remote_balance
         {
             get { return _remote_balance; }
-            set 
+            set
             {
                 if (_remote_balance != value)
                 {
-                    _remote_balance = value; 
+                    _remote_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The amount calculated to be paid in fees for the current set of commitment
         /// transactions. The fee amount is persisted with the channel in order to
@@ -3316,30 +3316,30 @@ namespace BTCPayServer.Lightning.LND
         public string Commit_fee
         {
             get { return _commit_fee; }
-            set 
+            set
             {
                 if (_commit_fee != value)
                 {
-                    _commit_fee = value; 
+                    _commit_fee = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("commit_weight", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Commit_weight
         {
             get { return _commit_weight; }
-            set 
+            set
             {
                 if (_commit_weight != value)
                 {
-                    _commit_weight = value; 
+                    _commit_weight = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The required number of satoshis per kilo-weight that the requester will pay
         /// at all times, for both the funding transaction and commitment transaction.
@@ -3348,94 +3348,94 @@ namespace BTCPayServer.Lightning.LND
         public string Fee_per_kw
         {
             get { return _fee_per_kw; }
-            set 
+            set
             {
                 if (_fee_per_kw != value)
                 {
-                    _fee_per_kw = value; 
+                    _fee_per_kw = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("unsettled_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Unsettled_balance
         {
             get { return _unsettled_balance; }
-            set 
+            set
             {
                 if (_unsettled_balance != value)
                 {
-                    _unsettled_balance = value; 
+                    _unsettled_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The total number of satoshis we've sent within this channel.</summary>
         [Newtonsoft.Json.JsonProperty("total_satoshis_sent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Total_satoshis_sent
         {
             get { return _total_satoshis_sent; }
-            set 
+            set
             {
                 if (_total_satoshis_sent != value)
                 {
-                    _total_satoshis_sent = value; 
+                    _total_satoshis_sent = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The total number of satoshis we've received within this channel.</summary>
         [Newtonsoft.Json.JsonProperty("total_satoshis_received", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Total_satoshis_received
         {
             get { return _total_satoshis_received; }
-            set 
+            set
             {
                 if (_total_satoshis_received != value)
                 {
-                    _total_satoshis_received = value; 
+                    _total_satoshis_received = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The total number of updates conducted within this channel.</summary>
         [Newtonsoft.Json.JsonProperty("num_updates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Num_updates
         {
             get { return _num_updates; }
-            set 
+            set
             {
                 if (_num_updates != value)
                 {
-                    _num_updates = value; 
+                    _num_updates = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The list of active, uncleared HTLCs currently pending within the channel.</summary>
         [Newtonsoft.Json.JsonProperty("pending_htlcs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcHTLC> Pending_htlcs
         {
             get { return _pending_htlcs; }
-            set 
+            set
             {
                 if (_pending_htlcs != value)
                 {
-                    _pending_htlcs = value; 
+                    _pending_htlcs = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The CSV delay expressed in relative blocks. If the channel is force
         /// closed, we'll need to wait for this many blocks before we can regain our
@@ -3444,158 +3444,158 @@ namespace BTCPayServer.Lightning.LND
         public long? Csv_delay
         {
             get { return _csv_delay; }
-            set 
+            set
             {
                 if (_csv_delay != value)
                 {
-                    _csv_delay = value; 
+                    _csv_delay = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("private", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Private
         {
             get { return _private; }
-            set 
+            set
             {
                 if (_private != value)
                 {
-                    _private = value; 
+                    _private = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannel FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannel>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannelBalanceResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _balance;
         private string _pending_open_balance;
-    
+
         [Newtonsoft.Json.JsonProperty("balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Balance
         {
             get { return _balance; }
-            set 
+            set
             {
                 if (_balance != value)
                 {
-                    _balance = value; 
+                    _balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("pending_open_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Pending_open_balance
         {
             get { return _pending_open_balance; }
-            set 
+            set
             {
                 if (_pending_open_balance != value)
                 {
-                    _pending_open_balance = value; 
+                    _pending_open_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelBalanceResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelBalanceResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannelCloseUpdate : System.ComponentModel.INotifyPropertyChanged
     {
         private byte[] _closing_txid;
         private bool? _success;
-    
+
         [Newtonsoft.Json.JsonProperty("closing_txid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Closing_txid
         {
             get { return _closing_txid; }
-            set 
+            set
             {
                 if (_closing_txid != value)
                 {
-                    _closing_txid = value; 
+                    _closing_txid = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("success", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Success
         {
             get { return _success; }
-            set 
+            set
             {
                 if (_success != value)
                 {
-                    _success = value; 
+                    _success = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelCloseUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelCloseUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     /// <summary>*
     /// A fully authenticated channel along with all its unique attributes.
     /// Once an authenticated channel announcement has been processed on the network,
@@ -3613,7 +3613,7 @@ namespace BTCPayServer.Lightning.LND
         private string _capacity;
         private LnrpcRoutingPolicy _node1_policy;
         private LnrpcRoutingPolicy _node2_policy;
-    
+
         /// <summary>*
         /// The unique channel ID for the channel. The first 3 bytes are the block
         /// height, the next 3 the index within the block, and the last 2 bytes are the
@@ -3622,134 +3622,134 @@ namespace BTCPayServer.Lightning.LND
         public string Channel_id
         {
             get { return _channel_id; }
-            set 
+            set
             {
                 if (_channel_id != value)
                 {
-                    _channel_id = value; 
+                    _channel_id = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("chan_point", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Chan_point
         {
             get { return _chan_point; }
-            set 
+            set
             {
                 if (_chan_point != value)
                 {
-                    _chan_point = value; 
+                    _chan_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("last_update", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Last_update
         {
             get { return _last_update; }
-            set 
+            set
             {
                 if (_last_update != value)
                 {
-                    _last_update = value; 
+                    _last_update = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("node1_pub", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Node1_pub
         {
             get { return _node1_pub; }
-            set 
+            set
             {
                 if (_node1_pub != value)
                 {
-                    _node1_pub = value; 
+                    _node1_pub = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("node2_pub", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Node2_pub
         {
             get { return _node2_pub; }
-            set 
+            set
             {
                 if (_node2_pub != value)
                 {
-                    _node2_pub = value; 
+                    _node2_pub = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Capacity
         {
             get { return _capacity; }
-            set 
+            set
             {
                 if (_capacity != value)
                 {
-                    _capacity = value; 
+                    _capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("node1_policy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcRoutingPolicy Node1_policy
         {
             get { return _node1_policy; }
-            set 
+            set
             {
                 if (_node1_policy != value)
                 {
-                    _node1_policy = value; 
+                    _node1_policy = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("node2_policy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcRoutingPolicy Node2_policy
         {
             get { return _node2_policy; }
-            set 
+            set
             {
                 if (_node2_policy != value)
                 {
-                    _node2_policy = value; 
+                    _node2_policy = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelEdge FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelEdge>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannelEdgeUpdate : System.ComponentModel.INotifyPropertyChanged
     {
@@ -3759,7 +3759,7 @@ namespace BTCPayServer.Lightning.LND
         private LnrpcRoutingPolicy _routing_policy;
         private string _advertising_node;
         private string _connecting_node;
-    
+
         /// <summary>*
         /// The unique channel ID for the channel. The first 3 bytes are the block
         /// height, the next 3 the index within the block, and the last 2 bytes are the
@@ -3768,106 +3768,106 @@ namespace BTCPayServer.Lightning.LND
         public string Chan_id
         {
             get { return _chan_id; }
-            set 
+            set
             {
                 if (_chan_id != value)
                 {
-                    _chan_id = value; 
+                    _chan_id = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("chan_point", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcChannelPoint Chan_point
         {
             get { return _chan_point; }
-            set 
+            set
             {
                 if (_chan_point != value)
                 {
-                    _chan_point = value; 
+                    _chan_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Capacity
         {
             get { return _capacity; }
-            set 
+            set
             {
                 if (_capacity != value)
                 {
-                    _capacity = value; 
+                    _capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("routing_policy", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcRoutingPolicy Routing_policy
         {
             get { return _routing_policy; }
-            set 
+            set
             {
                 if (_routing_policy != value)
                 {
-                    _routing_policy = value; 
+                    _routing_policy = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("advertising_node", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Advertising_node
         {
             get { return _advertising_node; }
-            set 
+            set
             {
                 if (_advertising_node != value)
                 {
-                    _advertising_node = value; 
+                    _advertising_node = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("connecting_node", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Connecting_node
         {
             get { return _connecting_node; }
-            set 
+            set
             {
                 if (_connecting_node != value)
                 {
-                    _connecting_node = value; 
+                    _connecting_node = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelEdgeUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelEdgeUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannelFeeReport : System.ComponentModel.INotifyPropertyChanged
     {
@@ -3875,319 +3875,319 @@ namespace BTCPayServer.Lightning.LND
         private string _base_fee_msat;
         private string _fee_per_mil;
         private double? _fee_rate;
-    
+
         /// <summary>/ The channel that this fee report belongs to.</summary>
         [Newtonsoft.Json.JsonProperty("chan_point", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Chan_point
         {
             get { return _chan_point; }
-            set 
+            set
             {
                 if (_chan_point != value)
                 {
-                    _chan_point = value; 
+                    _chan_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The base fee charged regardless of the number of milli-satoshis sent.</summary>
         [Newtonsoft.Json.JsonProperty("base_fee_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Base_fee_msat
         {
             get { return _base_fee_msat; }
-            set 
+            set
             {
                 if (_base_fee_msat != value)
                 {
-                    _base_fee_msat = value; 
+                    _base_fee_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The amount charged per milli-satoshis transferred expressed in millionths of a satoshi.</summary>
         [Newtonsoft.Json.JsonProperty("fee_per_mil", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fee_per_mil
         {
             get { return _fee_per_mil; }
-            set 
+            set
             {
                 if (_fee_per_mil != value)
                 {
-                    _fee_per_mil = value; 
+                    _fee_per_mil = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The effective fee rate in milli-satoshis. Computed by dividing the fee_per_mil value by 1 million.</summary>
         [Newtonsoft.Json.JsonProperty("fee_rate", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Fee_rate
         {
             get { return _fee_rate; }
-            set 
+            set
             {
                 if (_fee_rate != value)
                 {
-                    _fee_rate = value; 
+                    _fee_rate = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelFeeReport FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelFeeReport>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     /// <summary>/ Returns a new instance of the directed channel graph.</summary>
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannelGraph : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcLightningNode> _nodes;
         private System.Collections.ObjectModel.ObservableCollection<LnrpcChannelEdge> _edges;
-    
+
         [Newtonsoft.Json.JsonProperty("nodes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcLightningNode> Nodes
         {
             get { return _nodes; }
-            set 
+            set
             {
                 if (_nodes != value)
                 {
-                    _nodes = value; 
+                    _nodes = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("edges", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcChannelEdge> Edges
         {
             get { return _edges; }
-            set 
+            set
             {
                 if (_edges != value)
                 {
-                    _edges = value; 
+                    _edges = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelGraph FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelGraph>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannelOpenUpdate : System.ComponentModel.INotifyPropertyChanged
     {
         private LnrpcChannelPoint _channel_point;
-    
+
         [Newtonsoft.Json.JsonProperty("channel_point", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcChannelPoint Channel_point
         {
             get { return _channel_point; }
-            set 
+            set
             {
                 if (_channel_point != value)
                 {
-                    _channel_point = value; 
+                    _channel_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelOpenUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelOpenUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcChannelPoint : System.ComponentModel.INotifyPropertyChanged
     {
         private byte[] _funding_txid_bytes;
         private string _funding_txid_str;
         private long? _output_index;
-    
+
         [Newtonsoft.Json.JsonProperty("funding_txid_bytes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Funding_txid_bytes
         {
             get { return _funding_txid_bytes; }
-            set 
+            set
             {
                 if (_funding_txid_bytes != value)
                 {
-                    _funding_txid_bytes = value; 
+                    _funding_txid_bytes = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("funding_txid_str", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Funding_txid_str
         {
             get { return _funding_txid_str; }
-            set 
+            set
             {
                 if (_funding_txid_str != value)
                 {
-                    _funding_txid_str = value; 
+                    _funding_txid_str = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("output_index", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Output_index
         {
             get { return _output_index; }
-            set 
+            set
             {
                 if (_output_index != value)
                 {
-                    _output_index = value; 
+                    _output_index = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcChannelPoint FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcChannelPoint>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcCloseStatusUpdate : System.ComponentModel.INotifyPropertyChanged
     {
         private LnrpcPendingUpdate _close_pending;
         private LnrpcConfirmationUpdate _confirmation;
         private LnrpcChannelCloseUpdate _chan_close;
-    
+
         [Newtonsoft.Json.JsonProperty("close_pending", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcPendingUpdate Close_pending
         {
             get { return _close_pending; }
-            set 
+            set
             {
                 if (_close_pending != value)
                 {
-                    _close_pending = value; 
+                    _close_pending = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("confirmation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcConfirmationUpdate Confirmation
         {
             get { return _confirmation; }
-            set 
+            set
             {
                 if (_confirmation != value)
                 {
-                    _confirmation = value; 
+                    _confirmation = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("chan_close", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcChannelCloseUpdate Chan_close
         {
             get { return _chan_close; }
-            set 
+            set
             {
                 if (_chan_close != value)
                 {
-                    _chan_close = value; 
+                    _chan_close = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcCloseStatusUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcCloseStatusUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcClosedChannelUpdate : System.ComponentModel.INotifyPropertyChanged
     {
@@ -4195,7 +4195,7 @@ namespace BTCPayServer.Lightning.LND
         private string _capacity;
         private long? _closed_height;
         private LnrpcChannelPoint _chan_point;
-    
+
         /// <summary>*
         /// The unique channel ID for the channel. The first 3 bytes are the block
         /// height, the next 3 the index within the block, and the last 2 bytes are the
@@ -4204,242 +4204,242 @@ namespace BTCPayServer.Lightning.LND
         public string Chan_id
         {
             get { return _chan_id; }
-            set 
+            set
             {
                 if (_chan_id != value)
                 {
-                    _chan_id = value; 
+                    _chan_id = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Capacity
         {
             get { return _capacity; }
-            set 
+            set
             {
                 if (_capacity != value)
                 {
-                    _capacity = value; 
+                    _capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("closed_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Closed_height
         {
             get { return _closed_height; }
-            set 
+            set
             {
                 if (_closed_height != value)
                 {
-                    _closed_height = value; 
+                    _closed_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("chan_point", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcChannelPoint Chan_point
         {
             get { return _chan_point; }
-            set 
+            set
             {
                 if (_chan_point != value)
                 {
-                    _chan_point = value; 
+                    _chan_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcClosedChannelUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcClosedChannelUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcConfirmationUpdate : System.ComponentModel.INotifyPropertyChanged
     {
         private byte[] _block_sha;
         private int? _block_height;
         private long? _num_confs_left;
-    
+
         [Newtonsoft.Json.JsonProperty("block_sha", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Block_sha
         {
             get { return _block_sha; }
-            set 
+            set
             {
                 if (_block_sha != value)
                 {
-                    _block_sha = value; 
+                    _block_sha = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("block_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? Block_height
         {
             get { return _block_height; }
-            set 
+            set
             {
                 if (_block_height != value)
                 {
-                    _block_height = value; 
+                    _block_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_confs_left", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_confs_left
         {
             get { return _num_confs_left; }
-            set 
+            set
             {
                 if (_num_confs_left != value)
                 {
-                    _num_confs_left = value; 
+                    _num_confs_left = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcConfirmationUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcConfirmationUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcConnectPeerRequest : System.ComponentModel.INotifyPropertyChanged
     {
         private LnrpcLightningAddress _addr;
         private bool? _perm;
-    
+
         [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcLightningAddress Addr
         {
             get { return _addr; }
-            set 
+            set
             {
                 if (_addr != value)
                 {
-                    _addr = value; 
+                    _addr = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>* If set, the daemon will attempt to persistently connect to the target
         /// peer.  Otherwise, the call will be synchronous.</summary>
         [Newtonsoft.Json.JsonProperty("perm", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Perm
         {
             get { return _perm; }
-            set 
+            set
             {
                 if (_perm != value)
                 {
-                    _perm = value; 
+                    _perm = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcConnectPeerRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcConnectPeerRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcDebugLevelResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _sub_systems;
-    
+
         [Newtonsoft.Json.JsonProperty("sub_systems", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Sub_systems
         {
             get { return _sub_systems; }
-            set 
+            set
             {
                 if (_sub_systems != value)
                 {
-                    _sub_systems = value; 
+                    _sub_systems = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcDebugLevelResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcDebugLevelResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcFeeReportResponse : System.ComponentModel.INotifyPropertyChanged
     {
@@ -4447,87 +4447,87 @@ namespace BTCPayServer.Lightning.LND
         private string _day_fee_sum;
         private string _week_fee_sum;
         private string _month_fee_sum;
-    
+
         /// <summary>/ An array of channel fee reports which describes the current fee schedule for each channel.</summary>
         [Newtonsoft.Json.JsonProperty("channel_fees", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcChannelFeeReport> Channel_fees
         {
             get { return _channel_fees; }
-            set 
+            set
             {
                 if (_channel_fees != value)
                 {
-                    _channel_fees = value; 
+                    _channel_fees = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The total amount of fee revenue (in satoshis) the switch has collected over the past 24 hrs.</summary>
         [Newtonsoft.Json.JsonProperty("day_fee_sum", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Day_fee_sum
         {
             get { return _day_fee_sum; }
-            set 
+            set
             {
                 if (_day_fee_sum != value)
                 {
-                    _day_fee_sum = value; 
+                    _day_fee_sum = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The total amount of fee revenue (in satoshis) the switch has collected over the past 1 week.</summary>
         [Newtonsoft.Json.JsonProperty("week_fee_sum", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Week_fee_sum
         {
             get { return _week_fee_sum; }
-            set 
+            set
             {
                 if (_week_fee_sum != value)
                 {
-                    _week_fee_sum = value; 
+                    _week_fee_sum = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The total amount of fee revenue (in satoshis) the switch has collected over the past 1 month.</summary>
         [Newtonsoft.Json.JsonProperty("month_fee_sum", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Month_fee_sum
         {
             get { return _month_fee_sum; }
-            set 
+            set
             {
                 if (_month_fee_sum != value)
                 {
-                    _month_fee_sum = value; 
+                    _month_fee_sum = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcFeeReportResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcFeeReportResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcForwardingEvent : System.ComponentModel.INotifyPropertyChanged
     {
@@ -4537,117 +4537,117 @@ namespace BTCPayServer.Lightning.LND
         private string _amt_in;
         private string _amt_out;
         private string _fee;
-    
+
         /// <summary>/ Timestamp is the time (unix epoch offset) that this circuit was completed.</summary>
         [Newtonsoft.Json.JsonProperty("timestamp", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Timestamp
         {
             get { return _timestamp; }
-            set 
+            set
             {
                 if (_timestamp != value)
                 {
-                    _timestamp = value; 
+                    _timestamp = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The incoming channel ID that carried the HTLC that created the circuit.</summary>
         [Newtonsoft.Json.JsonProperty("chan_id_in", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Chan_id_in
         {
             get { return _chan_id_in; }
-            set 
+            set
             {
                 if (_chan_id_in != value)
                 {
-                    _chan_id_in = value; 
+                    _chan_id_in = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The outgoing channel ID that carried the preimage that completed the circuit.</summary>
         [Newtonsoft.Json.JsonProperty("chan_id_out", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Chan_id_out
         {
             get { return _chan_id_out; }
-            set 
+            set
             {
                 if (_chan_id_out != value)
                 {
-                    _chan_id_out = value; 
+                    _chan_id_out = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The total amount of the incoming HTLC that created half the circuit.</summary>
         [Newtonsoft.Json.JsonProperty("amt_in", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amt_in
         {
             get { return _amt_in; }
-            set 
+            set
             {
                 if (_amt_in != value)
                 {
-                    _amt_in = value; 
+                    _amt_in = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The total amount of the outgoign HTLC that created the second half of the circuit.</summary>
         [Newtonsoft.Json.JsonProperty("amt_out", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amt_out
         {
             get { return _amt_out; }
-            set 
+            set
             {
                 if (_amt_out != value)
                 {
-                    _amt_out = value; 
+                    _amt_out = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The total fee that this payment circuit carried.</summary>
         [Newtonsoft.Json.JsonProperty("fee", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fee
         {
             get { return _fee; }
-            set 
+            set
             {
                 if (_fee != value)
                 {
-                    _fee = value; 
+                    _fee = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcForwardingEvent FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcForwardingEvent>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcForwardingHistoryRequest : System.ComponentModel.INotifyPropertyChanged
     {
@@ -4655,149 +4655,149 @@ namespace BTCPayServer.Lightning.LND
         private string _end_time;
         private long? _index_offset;
         private long? _num_max_events;
-    
+
         /// <summary>/ Start time is the starting point of the forwarding history request. All records beyond this point will be included, respecting the end time, and the index offset.</summary>
         [Newtonsoft.Json.JsonProperty("start_time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Start_time
         {
             get { return _start_time; }
-            set 
+            set
             {
                 if (_start_time != value)
                 {
-                    _start_time = value; 
+                    _start_time = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ End time is the end point of the forwarding history request. The response will carry at most 50k records between the start time and the end time. The index offset can be used to implement pagination.</summary>
         [Newtonsoft.Json.JsonProperty("end_time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string End_time
         {
             get { return _end_time; }
-            set 
+            set
             {
                 if (_end_time != value)
                 {
-                    _end_time = value; 
+                    _end_time = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ Index offset is the offset in the time series to start at. As each response can only contain 50k records, callers can use this to skip around within a packed time series.</summary>
         [Newtonsoft.Json.JsonProperty("index_offset", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Index_offset
         {
             get { return _index_offset; }
-            set 
+            set
             {
                 if (_index_offset != value)
                 {
-                    _index_offset = value; 
+                    _index_offset = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The max number of events to return in the response to this query.</summary>
         [Newtonsoft.Json.JsonProperty("num_max_events", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_max_events
         {
             get { return _num_max_events; }
-            set 
+            set
             {
                 if (_num_max_events != value)
                 {
-                    _num_max_events = value; 
+                    _num_max_events = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcForwardingHistoryRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcForwardingHistoryRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcForwardingHistoryResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcForwardingEvent> _forwarding_events;
         private long? _last_offset_index;
-    
+
         /// <summary>/ A list of forwarding events from the time slice of the time series specified in the request.</summary>
         [Newtonsoft.Json.JsonProperty("forwarding_events", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcForwardingEvent> Forwarding_events
         {
             get { return _forwarding_events; }
-            set 
+            set
             {
                 if (_forwarding_events != value)
                 {
-                    _forwarding_events = value; 
+                    _forwarding_events = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The index of the last time in the set of returned forwarding events. Can be used to seek further, pagination style.</summary>
         [Newtonsoft.Json.JsonProperty("last_offset_index", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Last_offset_index
         {
             get { return _last_offset_index; }
-            set 
+            set
             {
                 if (_last_offset_index != value)
                 {
-                    _last_offset_index = value; 
+                    _last_offset_index = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcForwardingHistoryResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcForwardingHistoryResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcGenSeedResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<string> _cipher_seed_mnemonic;
         private byte[] _enciphered_seed;
-    
+
         /// <summary>*
         /// cipher_seed_mnemonic is a 24-word mnemonic that encodes a prior aezeed
         /// cipher seed obtained by the user. This field is optional, as if not
@@ -4808,16 +4808,16 @@ namespace BTCPayServer.Lightning.LND
         public System.Collections.ObjectModel.ObservableCollection<string> Cipher_seed_mnemonic
         {
             get { return _cipher_seed_mnemonic; }
-            set 
+            set
             {
                 if (_cipher_seed_mnemonic != value)
                 {
-                    _cipher_seed_mnemonic = value; 
+                    _cipher_seed_mnemonic = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// enciphered_seed are the raw aezeed cipher seed bytes. This is the raw
         /// cipher text before run through our mnemonic encoding scheme.</summary>
@@ -4825,36 +4825,36 @@ namespace BTCPayServer.Lightning.LND
         public byte[] Enciphered_seed
         {
             get { return _enciphered_seed; }
-            set 
+            set
             {
                 if (_enciphered_seed != value)
                 {
-                    _enciphered_seed = value; 
+                    _enciphered_seed = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcGenSeedResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcGenSeedResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcGetInfoResponse : System.ComponentModel.INotifyPropertyChanged
     {
@@ -4871,267 +4871,267 @@ namespace BTCPayServer.Lightning.LND
         private System.Collections.ObjectModel.ObservableCollection<string> _uris;
         private string _best_header_timestamp;
         private string _version;
-    
+
         /// <summary>/ The identity pubkey of the current node.</summary>
         [Newtonsoft.Json.JsonProperty("identity_pubkey", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Identity_pubkey
         {
             get { return _identity_pubkey; }
-            set 
+            set
             {
                 if (_identity_pubkey != value)
                 {
-                    _identity_pubkey = value; 
+                    _identity_pubkey = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("alias", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Alias
         {
             get { return _alias; }
-            set 
+            set
             {
                 if (_alias != value)
                 {
-                    _alias = value; 
+                    _alias = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_pending_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_pending_channels
         {
             get { return _num_pending_channels; }
-            set 
+            set
             {
                 if (_num_pending_channels != value)
                 {
-                    _num_pending_channels = value; 
+                    _num_pending_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_active_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_active_channels
         {
             get { return _num_active_channels; }
-            set 
+            set
             {
                 if (_num_active_channels != value)
                 {
-                    _num_active_channels = value; 
+                    _num_active_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_peers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_peers
         {
             get { return _num_peers; }
-            set 
+            set
             {
                 if (_num_peers != value)
                 {
-                    _num_peers = value; 
+                    _num_peers = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("block_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Block_height
         {
             get { return _block_height; }
-            set 
+            set
             {
                 if (_block_height != value)
                 {
-                    _block_height = value; 
+                    _block_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("block_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Block_hash
         {
             get { return _block_hash; }
-            set 
+            set
             {
                 if (_block_hash != value)
                 {
-                    _block_hash = value; 
+                    _block_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("synced_to_chain", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Synced_to_chain
         {
             get { return _synced_to_chain; }
-            set 
+            set
             {
                 if (_synced_to_chain != value)
                 {
-                    _synced_to_chain = value; 
+                    _synced_to_chain = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("testnet", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Testnet
         {
             get { return _testnet; }
-            set 
+            set
             {
                 if (_testnet != value)
                 {
-                    _testnet = value; 
+                    _testnet = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The URIs of the current node.</summary>
         [Newtonsoft.Json.JsonProperty("uris", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<string> Uris
         {
             get { return _uris; }
-            set 
+            set
             {
                 if (_uris != value)
                 {
-                    _uris = value; 
+                    _uris = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("best_header_timestamp", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Best_header_timestamp
         {
             get { return _best_header_timestamp; }
-            set 
+            set
             {
                 if (_best_header_timestamp != value)
                 {
-                    _best_header_timestamp = value; 
+                    _best_header_timestamp = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The version of the LND software that the node is running.</summary>
         [Newtonsoft.Json.JsonProperty("version", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Version
         {
             get { return _version; }
-            set 
+            set
             {
                 if (_version != value)
                 {
-                    _version = value; 
+                    _version = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcGetInfoResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcGetInfoResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcGraphTopologyUpdate : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcNodeUpdate> _node_updates;
         private System.Collections.ObjectModel.ObservableCollection<LnrpcChannelEdgeUpdate> _channel_updates;
         private System.Collections.ObjectModel.ObservableCollection<LnrpcClosedChannelUpdate> _closed_chans;
-    
+
         [Newtonsoft.Json.JsonProperty("node_updates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcNodeUpdate> Node_updates
         {
             get { return _node_updates; }
-            set 
+            set
             {
                 if (_node_updates != value)
                 {
-                    _node_updates = value; 
+                    _node_updates = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("channel_updates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcChannelEdgeUpdate> Channel_updates
         {
             get { return _channel_updates; }
-            set 
+            set
             {
                 if (_channel_updates != value)
                 {
-                    _channel_updates = value; 
+                    _channel_updates = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("closed_chans", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcClosedChannelUpdate> Closed_chans
         {
             get { return _closed_chans; }
-            set 
+            set
             {
                 if (_closed_chans != value)
                 {
-                    _closed_chans = value; 
+                    _closed_chans = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcGraphTopologyUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcGraphTopologyUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcHTLC : System.ComponentModel.INotifyPropertyChanged
     {
@@ -5139,83 +5139,83 @@ namespace BTCPayServer.Lightning.LND
         private string _amount;
         private byte[] _hash_lock;
         private long? _expiration_height;
-    
+
         [Newtonsoft.Json.JsonProperty("incoming", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Incoming
         {
             get { return _incoming; }
-            set 
+            set
             {
                 if (_incoming != value)
                 {
-                    _incoming = value; 
+                    _incoming = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amount
         {
             get { return _amount; }
-            set 
+            set
             {
                 if (_amount != value)
                 {
-                    _amount = value; 
+                    _amount = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("hash_lock", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Hash_lock
         {
             get { return _hash_lock; }
-            set 
+            set
             {
                 if (_hash_lock != value)
                 {
-                    _hash_lock = value; 
+                    _hash_lock = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("expiration_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Expiration_height
         {
             get { return _expiration_height; }
-            set 
+            set
             {
                 if (_expiration_height != value)
                 {
-                    _expiration_height = value; 
+                    _expiration_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcHTLC FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcHTLC>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcHop : System.ComponentModel.INotifyPropertyChanged
     {
@@ -5226,7 +5226,7 @@ namespace BTCPayServer.Lightning.LND
         private long? _expiry;
         private string _amt_to_forward_msat;
         private string _fee_msat;
-    
+
         /// <summary>*
         /// The unique channel ID for the channel. The first 3 bytes are the block
         /// height, the next 3 the index within the block, and the last 2 bytes are the
@@ -5235,120 +5235,120 @@ namespace BTCPayServer.Lightning.LND
         public string Chan_id
         {
             get { return _chan_id; }
-            set 
+            set
             {
                 if (_chan_id != value)
                 {
-                    _chan_id = value; 
+                    _chan_id = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("chan_capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Chan_capacity
         {
             get { return _chan_capacity; }
-            set 
+            set
             {
                 if (_chan_capacity != value)
                 {
-                    _chan_capacity = value; 
+                    _chan_capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("amt_to_forward", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amt_to_forward
         {
             get { return _amt_to_forward; }
-            set 
+            set
             {
                 if (_amt_to_forward != value)
                 {
-                    _amt_to_forward = value; 
+                    _amt_to_forward = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("fee", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fee
         {
             get { return _fee; }
-            set 
+            set
             {
                 if (_fee != value)
                 {
-                    _fee = value; 
+                    _fee = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("expiry", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Expiry
         {
             get { return _expiry; }
-            set 
+            set
             {
                 if (_expiry != value)
                 {
-                    _expiry = value; 
+                    _expiry = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("amt_to_forward_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amt_to_forward_msat
         {
             get { return _amt_to_forward_msat; }
-            set 
+            set
             {
                 if (_amt_to_forward_msat != value)
                 {
-                    _amt_to_forward_msat = value; 
+                    _amt_to_forward_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("fee_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fee_msat
         {
             get { return _fee_msat; }
-            set 
+            set
             {
                 if (_fee_msat != value)
                 {
-                    _fee_msat = value; 
+                    _fee_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcHop FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcHop>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcHopHint : System.ComponentModel.INotifyPropertyChanged
     {
@@ -5357,52 +5357,52 @@ namespace BTCPayServer.Lightning.LND
         private long? _fee_base_msat;
         private long? _fee_proportional_millionths;
         private long? _cltv_expiry_delta;
-    
+
         /// <summary>/ The public key of the node at the start of the channel.</summary>
         [Newtonsoft.Json.JsonProperty("node_id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Node_id
         {
             get { return _node_id; }
-            set 
+            set
             {
                 if (_node_id != value)
                 {
-                    _node_id = value; 
+                    _node_id = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The unique identifier of the channel.</summary>
         [Newtonsoft.Json.JsonProperty("chan_id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Chan_id
         {
             get { return _chan_id; }
-            set 
+            set
             {
                 if (_chan_id != value)
                 {
-                    _chan_id = value; 
+                    _chan_id = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The base fee of the channel denominated in millisatoshis.</summary>
         [Newtonsoft.Json.JsonProperty("fee_base_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Fee_base_msat
         {
             get { return _fee_base_msat; }
-            set 
+            set
             {
                 if (_fee_base_msat != value)
                 {
-                    _fee_base_msat = value; 
+                    _fee_base_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The fee rate of the channel for sending one satoshi across it denominated in
         /// millionths of a satoshi.</summary>
@@ -5410,51 +5410,51 @@ namespace BTCPayServer.Lightning.LND
         public long? Fee_proportional_millionths
         {
             get { return _fee_proportional_millionths; }
-            set 
+            set
             {
                 if (_fee_proportional_millionths != value)
                 {
-                    _fee_proportional_millionths = value; 
+                    _fee_proportional_millionths = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The time-lock delta of the channel.</summary>
         [Newtonsoft.Json.JsonProperty("cltv_expiry_delta", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Cltv_expiry_delta
         {
             get { return _cltv_expiry_delta; }
-            set 
+            set
             {
                 if (_cltv_expiry_delta != value)
                 {
-                    _cltv_expiry_delta = value; 
+                    _cltv_expiry_delta = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcHopHint FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcHopHint>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcInitWalletRequest : System.ComponentModel.INotifyPropertyChanged
     {
@@ -5462,7 +5462,7 @@ namespace BTCPayServer.Lightning.LND
         private System.Collections.ObjectModel.ObservableCollection<string> _cipher_seed_mnemonic;
         private byte[] _aezeed_passphrase;
         private int? _recovery_window;
-    
+
         /// <summary>*
         /// wallet_password is the passphrase that should be used to encrypt the
         /// wallet. This MUST be at least 8 chars in length. After creation, this
@@ -5471,16 +5471,16 @@ namespace BTCPayServer.Lightning.LND
         public byte[] Wallet_password
         {
             get { return _wallet_password; }
-            set 
+            set
             {
                 if (_wallet_password != value)
                 {
-                    _wallet_password = value; 
+                    _wallet_password = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// cipher_seed_mnemonic is a 24-word mnemonic that encodes a prior aezeed
         /// cipher seed obtained by the user. This may have been generated by the
@@ -5489,16 +5489,16 @@ namespace BTCPayServer.Lightning.LND
         public System.Collections.ObjectModel.ObservableCollection<string> Cipher_seed_mnemonic
         {
             get { return _cipher_seed_mnemonic; }
-            set 
+            set
             {
                 if (_cipher_seed_mnemonic != value)
                 {
-                    _cipher_seed_mnemonic = value; 
+                    _cipher_seed_mnemonic = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// aezeed_passphrase is an optional user provided passphrase that will be used
         /// to encrypt the generated aezeed cipher seed.</summary>
@@ -5506,16 +5506,16 @@ namespace BTCPayServer.Lightning.LND
         public byte[] Aezeed_passphrase
         {
             get { return _aezeed_passphrase; }
-            set 
+            set
             {
                 if (_aezeed_passphrase != value)
                 {
-                    _aezeed_passphrase = value; 
+                    _aezeed_passphrase = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// recovery_window is an optional argument specifying the address lookahead
         /// when restoring a wallet seed. The recovery window applies to each
@@ -5526,36 +5526,36 @@ namespace BTCPayServer.Lightning.LND
         public int? Recovery_window
         {
             get { return _recovery_window; }
-            set 
+            set
             {
                 if (_recovery_window != value)
                 {
-                    _recovery_window = value; 
+                    _recovery_window = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcInitWalletRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcInitWalletRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcInvoice : System.ComponentModel.INotifyPropertyChanged
     {
@@ -5588,67 +5588,67 @@ namespace BTCPayServer.Lightning.LND
         public string Memo
         {
             get { return _memo; }
-            set 
+            set
             {
                 if (_memo != value)
                 {
-                    _memo = value; 
+                    _memo = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("receipt", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Receipt
         {
             get { return _receipt; }
-            set 
+            set
             {
                 if (_receipt != value)
                 {
-                    _receipt = value; 
+                    _receipt = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("r_preimage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] R_preimage
         {
             get { return _r_preimage; }
-            set 
+            set
             {
                 if (_r_preimage != value)
                 {
-                    _r_preimage = value; 
+                    _r_preimage = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("r_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] R_hash
         {
             get { return _r_hash; }
-            set 
+            set
             {
                 if (_r_hash != value)
                 {
-                    _r_hash = value; 
+                    _r_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Value
         {
             get { return _value; }
-            set 
+            set
             {
                 if (_value != value)
                 {
-                    _value = value; 
+                    _value = value;
                     RaisePropertyChanged();
                 }
             }
@@ -5685,44 +5685,44 @@ namespace BTCPayServer.Lightning.LND
         public bool? Settled
         {
             get { return _settled; }
-            set 
+            set
             {
                 if (_settled != value)
                 {
-                    _settled = value; 
+                    _settled = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("creation_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Creation_date
         {
             get { return _creation_date; }
-            set 
+            set
             {
                 if (_creation_date != value)
                 {
-                    _creation_date = value; 
+                    _creation_date = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("settle_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Settle_date
         {
             get { return _settle_date; }
-            set 
+            set
             {
                 if (_settle_date != value)
                 {
-                    _settle_date = value; 
+                    _settle_date = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// A bare-bones invoice for a payment within the Lightning Network.  With the
         /// details of the invoice, the sender has all the data necessary to send a
@@ -5731,16 +5731,16 @@ namespace BTCPayServer.Lightning.LND
         public string Payment_request
         {
             get { return _payment_request; }
-            set 
+            set
             {
                 if (_payment_request != value)
                 {
-                    _payment_request = value; 
+                    _payment_request = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// Hash (SHA-256) of a description of the payment. Used if the description of
         /// payment (memo) is too long to naturally fit within the description field
@@ -5749,61 +5749,61 @@ namespace BTCPayServer.Lightning.LND
         public byte[] Description_hash
         {
             get { return _description_hash; }
-            set 
+            set
             {
                 if (_description_hash != value)
                 {
-                    _description_hash = value; 
+                    _description_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ Payment request expiry time in seconds. Default is 3600 (1 hour).</summary>
         [Newtonsoft.Json.JsonProperty("expiry", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Expiry
         {
             get { return _expiry; }
-            set 
+            set
             {
                 if (_expiry != value)
                 {
-                    _expiry = value; 
+                    _expiry = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ Fallback on-chain address.</summary>
         [Newtonsoft.Json.JsonProperty("fallback_addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fallback_addr
         {
             get { return _fallback_addr; }
-            set 
+            set
             {
                 if (_fallback_addr != value)
                 {
-                    _fallback_addr = value; 
+                    _fallback_addr = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ Delta to use for the time-lock of the CLTV extended to the final hop.</summary>
         [Newtonsoft.Json.JsonProperty("cltv_expiry", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Cltv_expiry
         {
             get { return _cltv_expiry; }
-            set 
+            set
             {
                 if (_cltv_expiry != value)
                 {
-                    _cltv_expiry = value; 
+                    _cltv_expiry = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// Route hints that can each be individually used to assist in reaching the
         /// invoice's destination.</summary>
@@ -5811,105 +5811,105 @@ namespace BTCPayServer.Lightning.LND
         public System.Collections.ObjectModel.ObservableCollection<LnrpcRouteHint> Route_hints
         {
             get { return _route_hints; }
-            set 
+            set
             {
                 if (_route_hints != value)
                 {
-                    _route_hints = value; 
+                    _route_hints = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ Whether this invoice should include routing hints for private channels.</summary>
         [Newtonsoft.Json.JsonProperty("private", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Private
         {
             get { return _private; }
-            set 
+            set
             {
                 if (_private != value)
                 {
-                    _private = value; 
+                    _private = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcInvoice FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcInvoice>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcLightningAddress : System.ComponentModel.INotifyPropertyChanged
     {
         private string _pubkey;
         private string _host;
-    
+
         [Newtonsoft.Json.JsonProperty("pubkey", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Pubkey
         {
             get { return _pubkey; }
-            set 
+            set
             {
                 if (_pubkey != value)
                 {
-                    _pubkey = value; 
+                    _pubkey = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("host", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Host
         {
             get { return _host; }
-            set 
+            set
             {
                 if (_host != value)
                 {
-                    _host = value; 
+                    _host = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcLightningAddress FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcLightningAddress>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     /// <summary>*
     /// An individual vertex/node within the channel graph. A node is
     /// connected to other nodes by one or more channel edges emanating from it. As the
@@ -5923,253 +5923,253 @@ namespace BTCPayServer.Lightning.LND
         private string _alias;
         private System.Collections.ObjectModel.ObservableCollection<LnrpcNodeAddress> _addresses;
         private string _color;
-    
+
         [Newtonsoft.Json.JsonProperty("last_update", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Last_update
         {
             get { return _last_update; }
-            set 
+            set
             {
                 if (_last_update != value)
                 {
-                    _last_update = value; 
+                    _last_update = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("pub_key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Pub_key
         {
             get { return _pub_key; }
-            set 
+            set
             {
                 if (_pub_key != value)
                 {
-                    _pub_key = value; 
+                    _pub_key = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("alias", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Alias
         {
             get { return _alias; }
-            set 
+            set
             {
                 if (_alias != value)
                 {
-                    _alias = value; 
+                    _alias = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("addresses", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcNodeAddress> Addresses
         {
             get { return _addresses; }
-            set 
+            set
             {
                 if (_addresses != value)
                 {
-                    _addresses = value; 
+                    _addresses = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("color", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Color
         {
             get { return _color; }
-            set 
+            set
             {
                 if (_color != value)
                 {
-                    _color = value; 
+                    _color = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcLightningNode FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcLightningNode>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcListChannelsResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcChannel> _channels;
-    
+
         [Newtonsoft.Json.JsonProperty("channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcChannel> Channels
         {
             get { return _channels; }
-            set 
+            set
             {
                 if (_channels != value)
                 {
-                    _channels = value; 
+                    _channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcListChannelsResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListChannelsResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcListInvoiceResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcInvoice> _invoices;
-    
+
         [Newtonsoft.Json.JsonProperty("invoices", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcInvoice> Invoices
         {
             get { return _invoices; }
-            set 
+            set
             {
                 if (_invoices != value)
                 {
-                    _invoices = value; 
+                    _invoices = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcListInvoiceResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListInvoiceResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcListPaymentsResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcPayment> _payments;
-    
+
         [Newtonsoft.Json.JsonProperty("payments", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcPayment> Payments
         {
             get { return _payments; }
-            set 
+            set
             {
                 if (_payments != value)
                 {
-                    _payments = value; 
+                    _payments = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcListPaymentsResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListPaymentsResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcListPeersResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcPeer> _peers;
-    
+
         [Newtonsoft.Json.JsonProperty("peers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcPeer> Peers
         {
             get { return _peers; }
-            set 
+            set
             {
                 if (_peers != value)
                 {
-                    _peers = value; 
+                    _peers = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcListPeersResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcListPeersResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcNetworkInfo : System.ComponentModel.INotifyPropertyChanged
     {
@@ -6182,253 +6182,253 @@ namespace BTCPayServer.Lightning.LND
         private double? _avg_channel_size;
         private string _min_channel_size;
         private string _max_channel_size;
-    
+
         [Newtonsoft.Json.JsonProperty("graph_diameter", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Graph_diameter
         {
             get { return _graph_diameter; }
-            set 
+            set
             {
                 if (_graph_diameter != value)
                 {
-                    _graph_diameter = value; 
+                    _graph_diameter = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("avg_out_degree", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Avg_out_degree
         {
             get { return _avg_out_degree; }
-            set 
+            set
             {
                 if (_avg_out_degree != value)
                 {
-                    _avg_out_degree = value; 
+                    _avg_out_degree = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("max_out_degree", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Max_out_degree
         {
             get { return _max_out_degree; }
-            set 
+            set
             {
                 if (_max_out_degree != value)
                 {
-                    _max_out_degree = value; 
+                    _max_out_degree = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_nodes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_nodes
         {
             get { return _num_nodes; }
-            set 
+            set
             {
                 if (_num_nodes != value)
                 {
-                    _num_nodes = value; 
+                    _num_nodes = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_channels
         {
             get { return _num_channels; }
-            set 
+            set
             {
                 if (_num_channels != value)
                 {
-                    _num_channels = value; 
+                    _num_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("total_network_capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Total_network_capacity
         {
             get { return _total_network_capacity; }
-            set 
+            set
             {
                 if (_total_network_capacity != value)
                 {
-                    _total_network_capacity = value; 
+                    _total_network_capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("avg_channel_size", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Avg_channel_size
         {
             get { return _avg_channel_size; }
-            set 
+            set
             {
                 if (_avg_channel_size != value)
                 {
-                    _avg_channel_size = value; 
+                    _avg_channel_size = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("min_channel_size", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Min_channel_size
         {
             get { return _min_channel_size; }
-            set 
+            set
             {
                 if (_min_channel_size != value)
                 {
-                    _min_channel_size = value; 
+                    _min_channel_size = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("max_channel_size", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Max_channel_size
         {
             get { return _max_channel_size; }
-            set 
+            set
             {
                 if (_max_channel_size != value)
                 {
-                    _max_channel_size = value; 
+                    _max_channel_size = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcNetworkInfo FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNetworkInfo>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcNewAddressResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _address;
-    
+
         [Newtonsoft.Json.JsonProperty("address", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Address
         {
             get { return _address; }
-            set 
+            set
             {
                 if (_address != value)
                 {
-                    _address = value; 
+                    _address = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcNewAddressResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNewAddressResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcNodeAddress : System.ComponentModel.INotifyPropertyChanged
     {
         private string _network;
         private string _addr;
-    
+
         [Newtonsoft.Json.JsonProperty("network", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Network
         {
             get { return _network; }
-            set 
+            set
             {
                 if (_network != value)
                 {
-                    _network = value; 
+                    _network = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Addr
         {
             get { return _addr; }
-            set 
+            set
             {
                 if (_addr != value)
                 {
-                    _addr = value; 
+                    _addr = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcNodeAddress FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNodeAddress>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcNodeInfo : System.ComponentModel.INotifyPropertyChanged
     {
         private LnrpcLightningNode _node;
         private long? _num_channels;
         private string _total_capacity;
-    
+
         /// <summary>*
         /// An individual vertex/node within the channel graph. A node is
         /// connected to other nodes by one or more channel edges emanating from it. As
@@ -6438,64 +6438,64 @@ namespace BTCPayServer.Lightning.LND
         public LnrpcLightningNode Node
         {
             get { return _node; }
-            set 
+            set
             {
                 if (_node != value)
                 {
-                    _node = value; 
+                    _node = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Num_channels
         {
             get { return _num_channels; }
-            set 
+            set
             {
                 if (_num_channels != value)
                 {
-                    _num_channels = value; 
+                    _num_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("total_capacity", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Total_capacity
         {
             get { return _total_capacity; }
-            set 
+            set
             {
                 if (_total_capacity != value)
                 {
-                    _total_capacity = value; 
+                    _total_capacity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcNodeInfo FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNodeInfo>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcNodeUpdate : System.ComponentModel.INotifyPropertyChanged
     {
@@ -6503,83 +6503,83 @@ namespace BTCPayServer.Lightning.LND
         private string _identity_key;
         private byte[] _global_features;
         private string _alias;
-    
+
         [Newtonsoft.Json.JsonProperty("addresses", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<string> Addresses
         {
             get { return _addresses; }
-            set 
+            set
             {
                 if (_addresses != value)
                 {
-                    _addresses = value; 
+                    _addresses = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("identity_key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Identity_key
         {
             get { return _identity_key; }
-            set 
+            set
             {
                 if (_identity_key != value)
                 {
-                    _identity_key = value; 
+                    _identity_key = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("global_features", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Global_features
         {
             get { return _global_features; }
-            set 
+            set
             {
                 if (_global_features != value)
                 {
-                    _global_features = value; 
+                    _global_features = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("alias", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Alias
         {
             get { return _alias; }
-            set 
+            set
             {
                 if (_alias != value)
                 {
-                    _alias = value; 
+                    _alias = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcNodeUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcNodeUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcOpenChannelRequest : System.ComponentModel.INotifyPropertyChanged
     {
@@ -6592,227 +6592,227 @@ namespace BTCPayServer.Lightning.LND
         private bool? _private;
         private string _min_htlc_msat;
         private long? _remote_csv_delay;
-    
+
         [Newtonsoft.Json.JsonProperty("node_pubkey", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Node_pubkey
         {
             get { return _node_pubkey; }
-            set 
+            set
             {
                 if (_node_pubkey != value)
                 {
-                    _node_pubkey = value; 
+                    _node_pubkey = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("node_pubkey_string", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Node_pubkey_string
         {
             get { return _node_pubkey_string; }
-            set 
+            set
             {
                 if (_node_pubkey_string != value)
                 {
-                    _node_pubkey_string = value; 
+                    _node_pubkey_string = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("local_funding_amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Local_funding_amount
         {
             get { return _local_funding_amount; }
-            set 
+            set
             {
                 if (_local_funding_amount != value)
                 {
-                    _local_funding_amount = value; 
+                    _local_funding_amount = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("push_sat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Push_sat
         {
             get { return _push_sat; }
-            set 
+            set
             {
                 if (_push_sat != value)
                 {
-                    _push_sat = value; 
+                    _push_sat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The target number of blocks that the funding transaction should be confirmed by.</summary>
         [Newtonsoft.Json.JsonProperty("target_conf", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? Target_conf
         {
             get { return _target_conf; }
-            set 
+            set
             {
                 if (_target_conf != value)
                 {
-                    _target_conf = value; 
+                    _target_conf = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ A manual fee rate set in sat/byte that should be used when crafting the funding transaction.</summary>
         [Newtonsoft.Json.JsonProperty("sat_per_byte", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Sat_per_byte
         {
             get { return _sat_per_byte; }
-            set 
+            set
             {
                 if (_sat_per_byte != value)
                 {
-                    _sat_per_byte = value; 
+                    _sat_per_byte = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ Whether this channel should be private, not announced to the greater network.</summary>
         [Newtonsoft.Json.JsonProperty("private", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Private
         {
             get { return _private; }
-            set 
+            set
             {
                 if (_private != value)
                 {
-                    _private = value; 
+                    _private = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The minimum value in millisatoshi we will require for incoming HTLCs on the channel.</summary>
         [Newtonsoft.Json.JsonProperty("min_htlc_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Min_htlc_msat
         {
             get { return _min_htlc_msat; }
-            set 
+            set
             {
                 if (_min_htlc_msat != value)
                 {
-                    _min_htlc_msat = value; 
+                    _min_htlc_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The delay we require on the remote's commitment transaction. If this is not set, it will be scaled automatically with the channel size.</summary>
         [Newtonsoft.Json.JsonProperty("remote_csv_delay", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Remote_csv_delay
         {
             get { return _remote_csv_delay; }
-            set 
+            set
             {
                 if (_remote_csv_delay != value)
                 {
-                    _remote_csv_delay = value; 
+                    _remote_csv_delay = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcOpenChannelRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcOpenChannelRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcOpenStatusUpdate : System.ComponentModel.INotifyPropertyChanged
     {
         private LnrpcPendingUpdate _chan_pending;
         private LnrpcConfirmationUpdate _confirmation;
         private LnrpcChannelOpenUpdate _chan_open;
-    
+
         [Newtonsoft.Json.JsonProperty("chan_pending", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcPendingUpdate Chan_pending
         {
             get { return _chan_pending; }
-            set 
+            set
             {
                 if (_chan_pending != value)
                 {
-                    _chan_pending = value; 
+                    _chan_pending = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("confirmation", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcConfirmationUpdate Confirmation
         {
             get { return _confirmation; }
-            set 
+            set
             {
                 if (_confirmation != value)
                 {
-                    _confirmation = value; 
+                    _confirmation = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("chan_open", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcChannelOpenUpdate Chan_open
         {
             get { return _chan_open; }
-            set 
+            set
             {
                 if (_chan_open != value)
                 {
-                    _chan_open = value; 
+                    _chan_open = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcOpenStatusUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcOpenStatusUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcPayReq : System.ComponentModel.INotifyPropertyChanged
     {
@@ -6826,167 +6826,167 @@ namespace BTCPayServer.Lightning.LND
         private string _fallback_addr;
         private string _cltv_expiry;
         private System.Collections.ObjectModel.ObservableCollection<LnrpcRouteHint> _route_hints;
-    
+
         [Newtonsoft.Json.JsonProperty("destination", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Destination
         {
             get { return _destination; }
-            set 
+            set
             {
                 if (_destination != value)
                 {
-                    _destination = value; 
+                    _destination = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("payment_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Payment_hash
         {
             get { return _payment_hash; }
-            set 
+            set
             {
                 if (_payment_hash != value)
                 {
-                    _payment_hash = value; 
+                    _payment_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_satoshis", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Num_satoshis
         {
             get { return _num_satoshis; }
-            set 
+            set
             {
                 if (_num_satoshis != value)
                 {
-                    _num_satoshis = value; 
+                    _num_satoshis = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("timestamp", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Timestamp
         {
             get { return _timestamp; }
-            set 
+            set
             {
                 if (_timestamp != value)
                 {
-                    _timestamp = value; 
+                    _timestamp = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("expiry", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Expiry
         {
             get { return _expiry; }
-            set 
+            set
             {
                 if (_expiry != value)
                 {
-                    _expiry = value; 
+                    _expiry = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("description", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Description
         {
             get { return _description; }
-            set 
+            set
             {
                 if (_description != value)
                 {
-                    _description = value; 
+                    _description = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("description_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Description_hash
         {
             get { return _description_hash; }
-            set 
+            set
             {
                 if (_description_hash != value)
                 {
-                    _description_hash = value; 
+                    _description_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("fallback_addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fallback_addr
         {
             get { return _fallback_addr; }
-            set 
+            set
             {
                 if (_fallback_addr != value)
                 {
-                    _fallback_addr = value; 
+                    _fallback_addr = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("cltv_expiry", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Cltv_expiry
         {
             get { return _cltv_expiry; }
-            set 
+            set
             {
                 if (_cltv_expiry != value)
                 {
-                    _cltv_expiry = value; 
+                    _cltv_expiry = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("route_hints", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcRouteHint> Route_hints
         {
             get { return _route_hints; }
-            set 
+            set
             {
                 if (_route_hints != value)
                 {
-                    _route_hints = value; 
+                    _route_hints = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcPayReq FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPayReq>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcPayment : System.ComponentModel.INotifyPropertyChanged
     {
@@ -6996,111 +6996,111 @@ namespace BTCPayServer.Lightning.LND
         private System.Collections.ObjectModel.ObservableCollection<string> _path;
         private string _fee;
         private string _payment_preimage;
-    
+
         [Newtonsoft.Json.JsonProperty("payment_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Payment_hash
         {
             get { return _payment_hash; }
-            set 
+            set
             {
                 if (_payment_hash != value)
                 {
-                    _payment_hash = value; 
+                    _payment_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("value", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Value
         {
             get { return _value; }
-            set 
+            set
             {
                 if (_value != value)
                 {
-                    _value = value; 
+                    _value = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("creation_date", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Creation_date
         {
             get { return _creation_date; }
-            set 
+            set
             {
                 if (_creation_date != value)
                 {
-                    _creation_date = value; 
+                    _creation_date = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("path", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<string> Path
         {
             get { return _path; }
-            set 
+            set
             {
                 if (_path != value)
                 {
-                    _path = value; 
+                    _path = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("fee", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fee
         {
             get { return _fee; }
-            set 
+            set
             {
                 if (_fee != value)
                 {
-                    _fee = value; 
+                    _fee = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("payment_preimage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Payment_preimage
         {
             get { return _payment_preimage; }
-            set 
+            set
             {
                 if (_payment_preimage != value)
                 {
-                    _payment_preimage = value; 
+                    _payment_preimage = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcPayment FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPayment>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcPeer : System.ComponentModel.INotifyPropertyChanged
     {
@@ -7112,139 +7112,139 @@ namespace BTCPayServer.Lightning.LND
         private string _sat_recv;
         private bool? _inbound;
         private string _ping_time;
-    
+
         [Newtonsoft.Json.JsonProperty("pub_key", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Pub_key
         {
             get { return _pub_key; }
-            set 
+            set
             {
                 if (_pub_key != value)
                 {
-                    _pub_key = value; 
+                    _pub_key = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("address", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Address
         {
             get { return _address; }
-            set 
+            set
             {
                 if (_address != value)
                 {
-                    _address = value; 
+                    _address = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("bytes_sent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Bytes_sent
         {
             get { return _bytes_sent; }
-            set 
+            set
             {
                 if (_bytes_sent != value)
                 {
-                    _bytes_sent = value; 
+                    _bytes_sent = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("bytes_recv", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Bytes_recv
         {
             get { return _bytes_recv; }
-            set 
+            set
             {
                 if (_bytes_recv != value)
                 {
-                    _bytes_recv = value; 
+                    _bytes_recv = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("sat_sent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Sat_sent
         {
             get { return _sat_sent; }
-            set 
+            set
             {
                 if (_sat_sent != value)
                 {
-                    _sat_sent = value; 
+                    _sat_sent = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("sat_recv", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Sat_recv
         {
             get { return _sat_recv; }
-            set 
+            set
             {
                 if (_sat_recv != value)
                 {
-                    _sat_recv = value; 
+                    _sat_recv = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("inbound", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Inbound
         {
             get { return _inbound; }
-            set 
+            set
             {
                 if (_inbound != value)
                 {
-                    _inbound = value; 
+                    _inbound = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("ping_time", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Ping_time
         {
             get { return _ping_time; }
-            set 
+            set
             {
                 if (_ping_time != value)
                 {
-                    _ping_time = value; 
+                    _ping_time = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcPeer FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPeer>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcPendingChannelsResponse : System.ComponentModel.INotifyPropertyChanged
     {
@@ -7253,97 +7253,97 @@ namespace BTCPayServer.Lightning.LND
         private System.Collections.ObjectModel.ObservableCollection<PendingChannelsResponseClosedChannel> _pending_closing_channels;
         private System.Collections.ObjectModel.ObservableCollection<PendingChannelsResponseForceClosedChannel> _pending_force_closing_channels;
         private System.Collections.ObjectModel.ObservableCollection<PendingChannelsResponseWaitingCloseChannel> _waiting_close_channels;
-    
+
         [Newtonsoft.Json.JsonProperty("total_limbo_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Total_limbo_balance
         {
             get { return _total_limbo_balance; }
-            set 
+            set
             {
                 if (_total_limbo_balance != value)
                 {
-                    _total_limbo_balance = value; 
+                    _total_limbo_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("pending_open_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<PendingChannelsResponsePendingOpenChannel> Pending_open_channels
         {
             get { return _pending_open_channels; }
-            set 
+            set
             {
                 if (_pending_open_channels != value)
                 {
-                    _pending_open_channels = value; 
+                    _pending_open_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("pending_closing_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<PendingChannelsResponseClosedChannel> Pending_closing_channels
         {
             get { return _pending_closing_channels; }
-            set 
+            set
             {
                 if (_pending_closing_channels != value)
                 {
-                    _pending_closing_channels = value; 
+                    _pending_closing_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("pending_force_closing_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<PendingChannelsResponseForceClosedChannel> Pending_force_closing_channels
         {
             get { return _pending_force_closing_channels; }
-            set 
+            set
             {
                 if (_pending_force_closing_channels != value)
                 {
-                    _pending_force_closing_channels = value; 
+                    _pending_force_closing_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("waiting_close_channels", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<PendingChannelsResponseWaitingCloseChannel> Waiting_close_channels
         {
             get { return _waiting_close_channels; }
-            set 
+            set
             {
                 if (_waiting_close_channels != value)
                 {
-                    _waiting_close_channels = value; 
+                    _waiting_close_channels = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcPendingChannelsResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPendingChannelsResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcPendingHTLC : System.ComponentModel.INotifyPropertyChanged
     {
@@ -7353,63 +7353,63 @@ namespace BTCPayServer.Lightning.LND
         private long? _maturity_height;
         private int? _blocks_til_maturity;
         private long? _stage;
-    
+
         [Newtonsoft.Json.JsonProperty("incoming", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Incoming
         {
             get { return _incoming; }
-            set 
+            set
             {
                 if (_incoming != value)
                 {
-                    _incoming = value; 
+                    _incoming = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amount
         {
             get { return _amount; }
-            set 
+            set
             {
                 if (_amount != value)
                 {
-                    _amount = value; 
+                    _amount = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("outpoint", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Outpoint
         {
             get { return _outpoint; }
-            set 
+            set
             {
                 if (_outpoint != value)
                 {
-                    _outpoint = value; 
+                    _outpoint = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("maturity_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Maturity_height
         {
             get { return _maturity_height; }
-            set 
+            set
             {
                 if (_maturity_height != value)
                 {
-                    _maturity_height = value; 
+                    _maturity_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The number of blocks remaining until the current stage can be swept.
         /// Negative values indicate how many blocks have passed since becoming
@@ -7418,104 +7418,104 @@ namespace BTCPayServer.Lightning.LND
         public int? Blocks_til_maturity
         {
             get { return _blocks_til_maturity; }
-            set 
+            set
             {
                 if (_blocks_til_maturity != value)
                 {
-                    _blocks_til_maturity = value; 
+                    _blocks_til_maturity = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("stage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Stage
         {
             get { return _stage; }
-            set 
+            set
             {
                 if (_stage != value)
                 {
-                    _stage = value; 
+                    _stage = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcPendingHTLC FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPendingHTLC>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcPendingUpdate : System.ComponentModel.INotifyPropertyChanged
     {
         private byte[] _txid;
         private long? _output_index;
-    
+
         [Newtonsoft.Json.JsonProperty("txid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Txid
         {
             get { return _txid; }
-            set 
+            set
             {
                 if (_txid != value)
                 {
-                    _txid = value; 
+                    _txid = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("output_index", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Output_index
         {
             get { return _output_index; }
-            set 
+            set
             {
                 if (_output_index != value)
                 {
-                    _output_index = value; 
+                    _output_index = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcPendingUpdate FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPendingUpdate>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcPolicyUpdateRequest : System.ComponentModel.INotifyPropertyChanged
     {
@@ -7524,141 +7524,141 @@ namespace BTCPayServer.Lightning.LND
         private string _base_fee_msat;
         private double? _fee_rate;
         private long? _time_lock_delta;
-    
+
         /// <summary>/ If set, then this update applies to all currently active channels.</summary>
         [Newtonsoft.Json.JsonProperty("global", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Global
         {
             get { return _global; }
-            set 
+            set
             {
                 if (_global != value)
                 {
-                    _global = value; 
+                    _global = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ If set, this update will target a specific channel.</summary>
         [Newtonsoft.Json.JsonProperty("chan_point", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcChannelPoint Chan_point
         {
             get { return _chan_point; }
-            set 
+            set
             {
                 if (_chan_point != value)
                 {
-                    _chan_point = value; 
+                    _chan_point = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The base fee charged regardless of the number of milli-satoshis sent.</summary>
         [Newtonsoft.Json.JsonProperty("base_fee_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Base_fee_msat
         {
             get { return _base_fee_msat; }
-            set 
+            set
             {
                 if (_base_fee_msat != value)
                 {
-                    _base_fee_msat = value; 
+                    _base_fee_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The effective fee rate in milli-satoshis. The precision of this value goes up to 6 decimal places, so 1e-6.</summary>
         [Newtonsoft.Json.JsonProperty("fee_rate", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double? Fee_rate
         {
             get { return _fee_rate; }
-            set 
+            set
             {
                 if (_fee_rate != value)
                 {
-                    _fee_rate = value; 
+                    _fee_rate = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The required timelock delta for HTLCs forwarded over the channel.</summary>
         [Newtonsoft.Json.JsonProperty("time_lock_delta", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Time_lock_delta
         {
             get { return _time_lock_delta; }
-            set 
+            set
             {
                 if (_time_lock_delta != value)
                 {
-                    _time_lock_delta = value; 
+                    _time_lock_delta = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcPolicyUpdateRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcPolicyUpdateRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcQueryRoutesResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcRoute> _routes;
-    
+
         [Newtonsoft.Json.JsonProperty("routes", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcRoute> Routes
         {
             get { return _routes; }
-            set 
+            set
             {
                 if (_routes != value)
                 {
-                    _routes = value; 
+                    _routes = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcQueryRoutesResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcQueryRoutesResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     /// <summary>*
     /// A path through the channel graph which runs over one or more channels in
     /// succession. This struct carries all the information required to craft the
@@ -7672,9 +7672,9 @@ namespace BTCPayServer.Lightning.LND
         private string _total_fees;
         private string _total_amt;
         private System.Collections.ObjectModel.ObservableCollection<LnrpcHop> _hops;
-        private string _total_fees_msat;
-        private string _total_amt_msat;
-    
+        private long _total_fees_msat;
+        private long _total_amt_msat;
+
         /// <summary>*
         /// The cumulative (final) time lock across the entire route.  This is the CLTV
         /// value that should be extended to the first hop in the route. All other hops
@@ -7684,16 +7684,16 @@ namespace BTCPayServer.Lightning.LND
         public long? Total_time_lock
         {
             get { return _total_time_lock; }
-            set 
+            set
             {
                 if (_total_time_lock != value)
                 {
-                    _total_time_lock = value; 
+                    _total_time_lock = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The sum of the fees paid at each hop within the final route.  In the case
         /// of a one-hop payment, this value will be zero as we don't need to pay a fee
@@ -7702,16 +7702,16 @@ namespace BTCPayServer.Lightning.LND
         public string Total_fees
         {
             get { return _total_fees; }
-            set 
+            set
             {
                 if (_total_fees != value)
                 {
-                    _total_fees = value; 
+                    _total_fees = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The total amount of funds required to complete a payment over this route.
         /// This value includes the cumulative fees at each hop. As a result, the HTLC
@@ -7722,89 +7722,89 @@ namespace BTCPayServer.Lightning.LND
         public string Total_amt
         {
             get { return _total_amt; }
-            set 
+            set
             {
                 if (_total_amt != value)
                 {
-                    _total_amt = value; 
+                    _total_amt = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// Contains details concerning the specific forwarding details at each hop.</summary>
         [Newtonsoft.Json.JsonProperty("hops", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcHop> Hops
         {
             get { return _hops; }
-            set 
+            set
             {
                 if (_hops != value)
                 {
-                    _hops = value; 
+                    _hops = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The total fees in millisatoshis.</summary>
         [Newtonsoft.Json.JsonProperty("total_fees_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Total_fees_msat
+        public long Total_fees_msat
         {
             get { return _total_fees_msat; }
-            set 
+            set
             {
                 if (_total_fees_msat != value)
                 {
-                    _total_fees_msat = value; 
+                    _total_fees_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// The total amount in millisatoshis.</summary>
         [Newtonsoft.Json.JsonProperty("total_amt_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string Total_amt_msat
+        public long Total_amt_msat
         {
             get { return _total_amt_msat; }
-            set 
+            set
             {
                 if (_total_amt_msat != value)
                 {
-                    _total_amt_msat = value; 
+                    _total_amt_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcRoute FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcRoute>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcRouteHint : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcHopHint> _hop_hints;
-    
+
         /// <summary>*
         /// A list of hop hints that when chained together can assist in reaching a
         /// specific destination.</summary>
@@ -7812,36 +7812,36 @@ namespace BTCPayServer.Lightning.LND
         public System.Collections.ObjectModel.ObservableCollection<LnrpcHopHint> Hop_hints
         {
             get { return _hop_hints; }
-            set 
+            set
             {
                 if (_hop_hints != value)
                 {
-                    _hop_hints = value; 
+                    _hop_hints = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcRouteHint FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcRouteHint>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcRoutingPolicy : System.ComponentModel.INotifyPropertyChanged
     {
@@ -7849,83 +7849,83 @@ namespace BTCPayServer.Lightning.LND
         private string _min_htlc;
         private string _fee_base_msat;
         private string _fee_rate_milli_msat;
-    
+
         [Newtonsoft.Json.JsonProperty("time_lock_delta", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public long? Time_lock_delta
         {
             get { return _time_lock_delta; }
-            set 
+            set
             {
                 if (_time_lock_delta != value)
                 {
-                    _time_lock_delta = value; 
+                    _time_lock_delta = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("min_htlc", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Min_htlc
         {
             get { return _min_htlc; }
-            set 
+            set
             {
                 if (_min_htlc != value)
                 {
-                    _min_htlc = value; 
+                    _min_htlc = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("fee_base_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fee_base_msat
         {
             get { return _fee_base_msat; }
-            set 
+            set
             {
                 if (_fee_base_msat != value)
                 {
-                    _fee_base_msat = value; 
+                    _fee_base_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("fee_rate_milli_msat", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Fee_rate_milli_msat
         {
             get { return _fee_rate_milli_msat; }
-            set 
+            set
             {
                 if (_fee_rate_milli_msat != value)
                 {
-                    _fee_rate_milli_msat = value; 
+                    _fee_rate_milli_msat = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcRoutingPolicy FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcRoutingPolicy>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcSendCoinsRequest : System.ComponentModel.INotifyPropertyChanged
     {
@@ -7933,163 +7933,163 @@ namespace BTCPayServer.Lightning.LND
         private string _amount;
         private int? _target_conf;
         private string _sat_per_byte;
-    
+
         [Newtonsoft.Json.JsonProperty("addr", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Addr
         {
             get { return _addr; }
-            set 
+            set
             {
                 if (_addr != value)
                 {
-                    _addr = value; 
+                    _addr = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amount
         {
             get { return _amount; }
-            set 
+            set
             {
                 if (_amount != value)
                 {
-                    _amount = value; 
+                    _amount = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The target number of blocks that this transaction should be confirmed by.</summary>
         [Newtonsoft.Json.JsonProperty("target_conf", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? Target_conf
         {
             get { return _target_conf; }
-            set 
+            set
             {
                 if (_target_conf != value)
                 {
-                    _target_conf = value; 
+                    _target_conf = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ A manual fee rate set in sat/byte that should be used when crafting the transaction.</summary>
         [Newtonsoft.Json.JsonProperty("sat_per_byte", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Sat_per_byte
         {
             get { return _sat_per_byte; }
-            set 
+            set
             {
                 if (_sat_per_byte != value)
                 {
-                    _sat_per_byte = value; 
+                    _sat_per_byte = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcSendCoinsRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSendCoinsRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcSendCoinsResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _txid;
-    
+
         [Newtonsoft.Json.JsonProperty("txid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Txid
         {
             get { return _txid; }
-            set 
+            set
             {
                 if (_txid != value)
                 {
-                    _txid = value; 
+                    _txid = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcSendCoinsResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSendCoinsResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcSendManyResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _txid;
-    
+
         [Newtonsoft.Json.JsonProperty("txid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Txid
         {
             get { return _txid; }
-            set 
+            set
             {
                 if (_txid != value)
                 {
-                    _txid = value; 
+                    _txid = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcSendManyResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSendManyResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcSendRequest : System.ComponentModel.INotifyPropertyChanged
     {
@@ -8100,78 +8100,78 @@ namespace BTCPayServer.Lightning.LND
         private string _payment_hash_string;
         private string _payment_request;
         private int? _final_cltv_delta;
-    
+
         [Newtonsoft.Json.JsonProperty("dest", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Dest
         {
             get { return _dest; }
-            set 
+            set
             {
                 if (_dest != value)
                 {
-                    _dest = value; 
+                    _dest = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("dest_string", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Dest_string
         {
             get { return _dest_string; }
-            set 
+            set
             {
                 if (_dest_string != value)
                 {
-                    _dest_string = value; 
+                    _dest_string = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ Number of satoshis to send.</summary>
         [Newtonsoft.Json.JsonProperty("amt", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amt
         {
             get { return _amt; }
-            set 
+            set
             {
                 if (_amt != value)
                 {
-                    _amt = value; 
+                    _amt = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("payment_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Payment_hash
         {
             get { return _payment_hash; }
-            set 
+            set
             {
                 if (_payment_hash != value)
                 {
-                    _payment_hash = value; 
+                    _payment_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("payment_hash_string", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Payment_hash_string
         {
             get { return _payment_hash_string; }
-            set 
+            set
             {
                 if (_payment_hash_string != value)
                 {
-                    _payment_hash_string = value; 
+                    _payment_hash_string = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// A bare-bones invoice for a payment within the Lightning Network.  With the
         /// details of the invoice, the sender has all the data necessary to send a
@@ -8180,159 +8180,159 @@ namespace BTCPayServer.Lightning.LND
         public string Payment_request
         {
             get { return _payment_request; }
-            set 
+            set
             {
                 if (_payment_request != value)
                 {
-                    _payment_request = value; 
+                    _payment_request = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>/ The CLTV delta from the current height that should be used to set the timelock for the final hop.</summary>
         [Newtonsoft.Json.JsonProperty("final_cltv_delta", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? Final_cltv_delta
         {
             get { return _final_cltv_delta; }
-            set 
+            set
             {
                 if (_final_cltv_delta != value)
                 {
-                    _final_cltv_delta = value; 
+                    _final_cltv_delta = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcSendRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSendRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcSendResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _payment_error;
         private byte[] _payment_preimage;
         private LnrpcRoute _payment_route;
-    
+
         [Newtonsoft.Json.JsonProperty("payment_error", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Payment_error
         {
             get { return _payment_error; }
-            set 
+            set
             {
                 if (_payment_error != value)
                 {
-                    _payment_error = value; 
+                    _payment_error = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("payment_preimage", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public byte[] Payment_preimage
         {
             get { return _payment_preimage; }
-            set 
+            set
             {
                 if (_payment_preimage != value)
                 {
-                    _payment_preimage = value; 
+                    _payment_preimage = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("payment_route", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public LnrpcRoute Payment_route
         {
             get { return _payment_route; }
-            set 
+            set
             {
                 if (_payment_route != value)
                 {
-                    _payment_route = value; 
+                    _payment_route = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcSendResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSendResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcSignMessageResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _signature;
-    
+
         [Newtonsoft.Json.JsonProperty("signature", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Signature
         {
             get { return _signature; }
-            set 
+            set
             {
                 if (_signature != value)
                 {
-                    _signature = value; 
+                    _signature = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcSignMessageResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcSignMessageResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcTransaction : System.ComponentModel.INotifyPropertyChanged
     {
@@ -8344,185 +8344,185 @@ namespace BTCPayServer.Lightning.LND
         private string _time_stamp;
         private string _total_fees;
         private System.Collections.ObjectModel.ObservableCollection<string> _dest_addresses;
-    
+
         [Newtonsoft.Json.JsonProperty("tx_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Tx_hash
         {
             get { return _tx_hash; }
-            set 
+            set
             {
                 if (_tx_hash != value)
                 {
-                    _tx_hash = value; 
+                    _tx_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("amount", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Amount
         {
             get { return _amount; }
-            set 
+            set
             {
                 if (_amount != value)
                 {
-                    _amount = value; 
+                    _amount = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("num_confirmations", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? Num_confirmations
         {
             get { return _num_confirmations; }
-            set 
+            set
             {
                 if (_num_confirmations != value)
                 {
-                    _num_confirmations = value; 
+                    _num_confirmations = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("block_hash", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Block_hash
         {
             get { return _block_hash; }
-            set 
+            set
             {
                 if (_block_hash != value)
                 {
-                    _block_hash = value; 
+                    _block_hash = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("block_height", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int? Block_height
         {
             get { return _block_height; }
-            set 
+            set
             {
                 if (_block_height != value)
                 {
-                    _block_height = value; 
+                    _block_height = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("time_stamp", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Time_stamp
         {
             get { return _time_stamp; }
-            set 
+            set
             {
                 if (_time_stamp != value)
                 {
-                    _time_stamp = value; 
+                    _time_stamp = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("total_fees", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Total_fees
         {
             get { return _total_fees; }
-            set 
+            set
             {
                 if (_total_fees != value)
                 {
-                    _total_fees = value; 
+                    _total_fees = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("dest_addresses", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<string> Dest_addresses
         {
             get { return _dest_addresses; }
-            set 
+            set
             {
                 if (_dest_addresses != value)
                 {
-                    _dest_addresses = value; 
+                    _dest_addresses = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcTransaction FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcTransaction>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcTransactionDetails : System.ComponentModel.INotifyPropertyChanged
     {
         private System.Collections.ObjectModel.ObservableCollection<LnrpcTransaction> _transactions;
-    
+
         /// <summary>/ The list of transactions relevant to the wallet.</summary>
         [Newtonsoft.Json.JsonProperty("transactions", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<LnrpcTransaction> Transactions
         {
             get { return _transactions; }
-            set 
+            set
             {
                 if (_transactions != value)
                 {
-                    _transactions = value; 
+                    _transactions = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcTransactionDetails FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcTransactionDetails>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcUnlockWalletRequest : System.ComponentModel.INotifyPropertyChanged
     {
         private byte[] _wallet_password;
         private int? _recovery_window;
-    
+
         /// <summary>*
         /// wallet_password should be the current valid passphrase for the daemon. This
         /// will be required to decrypt on-disk material that the daemon requires to
@@ -8531,16 +8531,16 @@ namespace BTCPayServer.Lightning.LND
         public byte[] Wallet_password
         {
             get { return _wallet_password; }
-            set 
+            set
             {
                 if (_wallet_password != value)
                 {
-                    _wallet_password = value; 
+                    _wallet_password = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         /// <summary>*
         /// recovery_window is an optional argument specifying the address lookahead
         /// when restoring a wallet seed. The recovery window applies to each
@@ -8551,155 +8551,155 @@ namespace BTCPayServer.Lightning.LND
         public int? Recovery_window
         {
             get { return _recovery_window; }
-            set 
+            set
             {
                 if (_recovery_window != value)
                 {
-                    _recovery_window = value; 
+                    _recovery_window = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcUnlockWalletRequest FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcUnlockWalletRequest>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcVerifyMessageResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private bool? _valid;
         private string _pubkey;
-    
+
         [Newtonsoft.Json.JsonProperty("valid", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public bool? Valid
         {
             get { return _valid; }
-            set 
+            set
             {
                 if (_valid != value)
                 {
-                    _valid = value; 
+                    _valid = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("pubkey", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Pubkey
         {
             get { return _pubkey; }
-            set 
+            set
             {
                 if (_pubkey != value)
                 {
-                    _pubkey = value; 
+                    _pubkey = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcVerifyMessageResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcVerifyMessageResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
-    
+
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcWalletBalanceResponse : System.ComponentModel.INotifyPropertyChanged
     {
         private string _total_balance;
         private string _confirmed_balance;
         private string _unconfirmed_balance;
-    
+
         [Newtonsoft.Json.JsonProperty("total_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Total_balance
         {
             get { return _total_balance; }
-            set 
+            set
             {
                 if (_total_balance != value)
                 {
-                    _total_balance = value; 
+                    _total_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("confirmed_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Confirmed_balance
         {
             get { return _confirmed_balance; }
-            set 
+            set
             {
                 if (_confirmed_balance != value)
                 {
-                    _confirmed_balance = value; 
+                    _confirmed_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         [Newtonsoft.Json.JsonProperty("unconfirmed_balance", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string Unconfirmed_balance
         {
             get { return _unconfirmed_balance; }
-            set 
+            set
             {
                 if (_unconfirmed_balance != value)
                 {
-                    _unconfirmed_balance = value; 
+                    _unconfirmed_balance = value;
                     RaisePropertyChanged();
                 }
             }
         }
-    
+
         public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-    
-        public string ToJson() 
+
+        public string ToJson()
         {
             return Newtonsoft.Json.JsonConvert.SerializeObject(this);
         }
-        
+
         public static LnrpcWalletBalanceResponse FromJson(string data)
         {
             return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcWalletBalanceResponse>(data);
         }
-    
+
         protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
         {
             var handler = PropertyChanged;
-            if (handler != null) 
+            if (handler != null)
                 handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
         }
     }
@@ -8713,11 +8713,11 @@ namespace BTCPayServer.Lightning.LND
 
         public System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> Headers { get; private set; }
 
-        public SwaggerException(string message, string statusCode, string response, System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException) 
+        public SwaggerException(string message, string statusCode, string response, System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Exception innerException)
             : base(message, innerException)
         {
             StatusCode = statusCode;
-            Response = response; 
+            Response = response;
             Headers = headers;
         }
 
@@ -8732,7 +8732,7 @@ namespace BTCPayServer.Lightning.LND
     {
         public TResult Result { get; private set; }
 
-        public SwaggerException(string message, string statusCode, string response, System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception innerException) 
+        public SwaggerException(string message, string statusCode, string response, System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>> headers, TResult result, System.Exception innerException)
             : base(message, statusCode, response, headers, innerException)
         {
             Result = result;

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -57,14 +57,14 @@ namespace BTCPayServer.Lightning.Tests
 				Assert.Null(retrievedInvoice);
 			}
 		}
-		
+
 		[Fact(Timeout = Timeout)]
 		public async Task CanCreateInvoiceWithDescriptionHash()
 		{
-			var hashToUse = 
+			var hashToUse =
 				new uint256(
 						new SHA256Managed().ComputeHash(Encoding.UTF8.GetBytes("CanCreateInvoiceWithDescriptionHash")));
-			
+
 			async Task<LightningInvoice> CreateWithHash(ILightningClient lightningClient)
 			{
 				return await lightningClient.CreateInvoice(new CreateInvoiceParams(10000, hashToUse,
@@ -88,8 +88,8 @@ namespace BTCPayServer.Lightning.Tests
 						var retrievedInvoiceeBOLT = BOLT11PaymentRequest.Parse(retrievedInvoice.BOLT11, Network.RegTest);
 						Assert.Equal(createdInvoiceBOLT.PaymentHash, retrievedInvoiceeBOLT.PaymentHash);
 						Assert.Equal(createdInvoiceBOLT.DescriptionHash, hashToUse);
-						
-						
+
+
 						break;
 					default:
 						await Assert.ThrowsAsync<NotSupportedException>(async () =>
@@ -98,11 +98,11 @@ namespace BTCPayServer.Lightning.Tests
 						});
 						break;
 				}
-				
+
 			}
 		}
-		
-		
+
+
 		[Fact(Timeout = Timeout)]
 		public async Task CanCancelInvoices()
 		{
@@ -114,7 +114,7 @@ namespace BTCPayServer.Lightning.Tests
 				await lightningClient.CancelInvoice(i.Id);
 				i = await lightningClient.GetInvoice(i.Id);
 				Assert.Null(i);
-				
+
 
 			}
 			await WaitServersAreUp();
@@ -135,7 +135,7 @@ namespace BTCPayServer.Lightning.Tests
 						});
 						break;
 				}
-				
+
 			}
 		}
 
@@ -237,6 +237,8 @@ namespace BTCPayServer.Lightning.Tests
 					var waiting = listener.WaitInvoice(default);
 					var paidReply = await test.Customer.Pay(invoice.BOLT11);
 					Assert.Equal(PayResult.Ok, paidReply.Result);
+                    Assert.Equal(amount, paidReply.Details.TotalAmount);
+                    Assert.Equal(0, paidReply.Details.FeeAmount);
 					var paidInvoice = await waiting;
 					Assert.Equal(LightningInvoiceStatus.Paid, paidInvoice.Status);
 					var retrievedInvoice = await test.Merchant.GetInvoice(invoice.Id);
@@ -371,7 +373,6 @@ namespace BTCPayServer.Lightning.Tests
 			}
 		}
 
-
 		private static void AssertUnpaid(LightningInvoice invoice, LightMoney expectedAmount = null)
 		{
 			expectedAmount ??= LightMoney.MilliSatoshis(10000);
@@ -384,11 +385,11 @@ namespace BTCPayServer.Lightning.Tests
 		private async Task EnsureConnectedToDestinations((string Name, ILightningClient Customer, ILightningClient Merchant) test)
 		{
 			await Task.WhenAll(WaitServersAreUp($"{test.Name} (Customer)", test.Customer), WaitServersAreUp($"{test.Name} (Merchant)", test.Merchant));
-			Tests.Logs.Tester.LogInformation($"{test.Name}: Connecting channels...");
+            Tests.Logs.Tester.LogInformation($"{test.Name}: Connecting channels...");
 			var cashcow = Tester.CreateRPC();
 			await cashcow.ScanRPCCapabilitiesAsync();
 			await ConnectChannels.ConnectAll(cashcow, new[] { test.Customer }, new[] { test.Merchant });
-			Tests.Logs.Tester.LogInformation($"{test.Name}: Channels connected");
+            Tests.Logs.Tester.LogInformation($"{test.Name}: Channels connected");
 		}
 
 		[Fact]


### PR DESCRIPTION
Adds `PayDetails` to the `PayResponse`, consisting of the total amount paid and the fees.

Added for c-lightning, LND and Eclair. Works for LNbank too, because it just passes the response through.