### PR TITLE
Add optional max fee percentage when paying

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -249,7 +249,7 @@ namespace BTCPayServer.Lightning.CLightning
 			return ToLightningInvoice(invoices[0]);
 		}
 
-        private async Task<PayResponse> PayAsync(string bolt11, float? maxFeePercent, CancellationToken cancellation)
+        private async Task<PayResponse> PayAsync(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation)
         {
             try
             {
@@ -257,7 +257,7 @@ namespace BTCPayServer.Lightning.CLightning
                     throw new ArgumentNullException(nameof(bolt11));
 
                 bolt11 = bolt11.Replace("lightning:", "").Replace("LIGHTNING:", "");
-                var response = await SendCommandAsync<CLightningPayResponse>("pay", new object[] { bolt11, null, null, null, maxFeePercent }, false, cancellation: cancellation);
+                var response = await SendCommandAsync<CLightningPayResponse>("pay", new object[] { bolt11, null, null, null, payParams?.MaxFeePercent }, false, cancellation: cancellation);
 
                 return new PayResponse(PayResult.Ok, new PayDetails
                 {
@@ -271,9 +271,9 @@ namespace BTCPayServer.Lightning.CLightning
             }
         }
 
-        async Task<PayResponse> ILightningClient.Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation)
+        async Task<PayResponse> ILightningClient.Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation)
         {
-            return await PayAsync(bolt11, maxFeePercent, cancellation);
+            return await PayAsync(bolt11, payParams, cancellation);
         }
 
         async Task<PayResponse> ILightningClient.Pay(string bolt11, CancellationToken cancellation)

--- a/src/BTCPayServer.Lightning.Charge/ChargeClient.cs
+++ b/src/BTCPayServer.Lightning.Charge/ChargeClient.cs
@@ -73,7 +73,6 @@ namespace BTCPayServer.Lightning.Charge
             }
 
             var handler = new HttpClientHandler();
-            
 
             if (allowInsecure) {
                 handler.ServerCertificateCustomValidationCallback = (request, cert, chain, errors) => true;
@@ -104,7 +103,7 @@ namespace BTCPayServer.Lightning.Charge
         public async Task<ChargeSession> Listen(CancellationToken cancellation = default(CancellationToken))
         {
             return new ChargeSession(
-                await WebsocketHelper.CreateClientWebSocket(Uri.ToString(), 
+                await WebsocketHelper.CreateClientWebSocket(Uri.ToString(),
                     $"Basic {ChargeAuthentication.GetBase64Creds()}", cancellation));
         }
 
@@ -199,6 +198,11 @@ namespace BTCPayServer.Lightning.Charge
         }
 
         Task<PayResponse> ILightningClient.Pay(string bolt11, CancellationToken cancellation)
+        {
+            throw new NotSupportedException();
+        }
+
+        Task<PayResponse> ILightningClient.Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation)
         {
             throw new NotSupportedException();
         }

--- a/src/BTCPayServer.Lightning.Charge/ChargeClient.cs
+++ b/src/BTCPayServer.Lightning.Charge/ChargeClient.cs
@@ -202,7 +202,7 @@ namespace BTCPayServer.Lightning.Charge
             throw new NotSupportedException();
         }
 
-        Task<PayResponse> ILightningClient.Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation)
+        Task<PayResponse> ILightningClient.Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation)
         {
             throw new NotSupportedException();
         }

--- a/src/BTCPayServer.Lightning.Common/ILightningClient.cs
+++ b/src/BTCPayServer.Lightning.Common/ILightningClient.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
@@ -9,17 +7,18 @@ namespace BTCPayServer.Lightning
 {
     public interface ILightningClient
     {
-        Task<LightningInvoice> GetInvoice(string invoiceId, CancellationToken cancellation = default(CancellationToken));
-        Task<LightningInvoice> CreateInvoice(LightMoney amount, string description, TimeSpan expiry, CancellationToken cancellation = default(CancellationToken));
-        Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest, CancellationToken cancellation = default(CancellationToken));
-        Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default(CancellationToken));
-        Task<LightningNodeInformation> GetInfo(CancellationToken cancellation = default(CancellationToken));
-        Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = default(CancellationToken));
-        Task<OpenChannelResponse> OpenChannel(OpenChannelRequest openChannelRequest, CancellationToken cancellation = default(CancellationToken));
+        Task<LightningInvoice> GetInvoice(string invoiceId, CancellationToken cancellation = default);
+        Task<LightningInvoice> CreateInvoice(LightMoney amount, string description, TimeSpan expiry, CancellationToken cancellation = default);
+        Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest, CancellationToken cancellation = default);
+        Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default);
+        Task<LightningNodeInformation> GetInfo(CancellationToken cancellation = default);
+        Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation = default);
+        Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = default);
+        Task<OpenChannelResponse> OpenChannel(OpenChannelRequest openChannelRequest, CancellationToken cancellation = default);
         Task<BitcoinAddress> GetDepositAddress();
         Task<ConnectionResult> ConnectTo(NodeInfo nodeInfo);
         Task CancelInvoice(string invoiceId);
-        Task<LightningChannel[]> ListChannels(CancellationToken cancellation = default(CancellationToken));
+        Task<LightningChannel[]> ListChannels(CancellationToken cancellation = default);
     }
 
     public interface ILightningInvoiceListener : IDisposable

--- a/src/BTCPayServer.Lightning.Common/ILightningClient.cs
+++ b/src/BTCPayServer.Lightning.Common/ILightningClient.cs
@@ -12,7 +12,7 @@ namespace BTCPayServer.Lightning
         Task<LightningInvoice> CreateInvoice(CreateInvoiceParams createInvoiceRequest, CancellationToken cancellation = default);
         Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default);
         Task<LightningNodeInformation> GetInfo(CancellationToken cancellation = default);
-        Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation = default);
+        Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation = default);
         Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = default);
         Task<OpenChannelResponse> OpenChannel(OpenChannelRequest openChannelRequest, CancellationToken cancellation = default);
         Task<BitcoinAddress> GetDepositAddress();

--- a/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
@@ -1,0 +1,16 @@
+namespace BTCPayServer.Lightning
+{
+    public class PayInvoiceParams
+    {
+        public PayInvoiceParams()
+        {
+        }
+
+        public PayInvoiceParams(float maxFeePercent)
+        {
+            MaxFeePercent = maxFeePercent;
+        }
+
+        public float? MaxFeePercent { get; set; }
+    }
+}

--- a/src/BTCPayServer.Lightning.Eclair/EclairClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairClient.cs
@@ -172,14 +172,15 @@ namespace BTCPayServer.Lightning.Eclair
 		}
 
 		public async Task<string> PayInvoice(string invoice, int? amountMsat = null, int? maxAttempts = null,
-			CancellationToken cts = default(CancellationToken))
+            int? maxFeePercent = null, CancellationToken cts = default(CancellationToken))
 		{
 			return await SendCommandAsync<PayInvoiceRequest, string>("payinvoice",
 				new PayInvoiceRequest()
 				{
 					Invoice = invoice,
 					AmountMsat = amountMsat,
-					MaxAttempts = maxAttempts
+					MaxAttempts = maxAttempts,
+                    MaxFeePct = maxFeePercent
 				}, cts);
 		}
 

--- a/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
@@ -130,11 +130,11 @@ namespace BTCPayServer.Lightning.Eclair
             return nodeInfo;
         }
 
-        public async Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation = default)
+        public async Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation = default)
         {
             try
             {
-                var maxFeePct = maxFeePercent > 0 ? (int)Math.Round(maxFeePercent.Value) : (int?)null;
+                var maxFeePct = payParams?.MaxFeePercent > 0 ? (int)Math.Round(payParams.MaxFeePercent.Value) : (int?)null;
                 var uuid = await _eclairClient.PayInvoice(bolt11, null, null, maxFeePct, cancellation);
                 while (!cancellation.IsCancellationRequested)
                 {

--- a/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
@@ -130,11 +130,12 @@ namespace BTCPayServer.Lightning.Eclair
             return nodeInfo;
         }
 
-        public async Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = default(CancellationToken))
+        public async Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation = default)
         {
             try
             {
-                var uuid = await _eclairClient.PayInvoice(bolt11, null, null, cancellation);
+                var maxFeePct = maxFeePercent > 0 ? (int)Math.Round(maxFeePercent.Value) : (int?)null;
+                var uuid = await _eclairClient.PayInvoice(bolt11, null, null, maxFeePct, cancellation);
                 while (!cancellation.IsCancellationRequested)
                 {
                     var status = await _eclairClient.GetSentInfo(null, uuid, cancellation);
@@ -165,6 +166,11 @@ namespace BTCPayServer.Lightning.Eclair
             }
 
             return new PayResponse(PayResult.CouldNotFindRoute);
+        }
+
+        public async Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = default)
+        {
+            return await Pay(bolt11, null, cancellation);
         }
 
         public async Task<OpenChannelResponse> OpenChannel(OpenChannelRequest openChannelRequest,

--- a/src/BTCPayServer.Lightning.Eclair/Models/PayInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/PayInvoiceRequest.cs
@@ -5,5 +5,6 @@ namespace BTCPayServer.Lightning.Eclair.Models
         public string Invoice { get; set; }
         public int? AmountMsat { get; set; }
         public int? MaxAttempts { get; set; }
+        public int? MaxFeePct { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -325,19 +325,19 @@ namespace BTCPayServer.Lightning.LND
                 .ToLower(CultureInfo.InvariantCulture);
         }
 
-        private async Task<PayResponse> PayAsync(string bolt11, float? maxFeePercent, CancellationToken cancellation)
+        private async Task<PayResponse> PayAsync(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation)
         {
             retry:
             var retryCount = 0;
             try
             {
                 var req = new LnrpcSendRequest { Payment_request = bolt11 };
-                if (maxFeePercent > 0)
+                if (payParams?.MaxFeePercent > 0)
                 {
                     req.Fee_limit = new LnrpcFeeLimit
                     {
                         // needs to be a string representation of an integer, not float
-                        Percent = ((int)Math.Round(maxFeePercent.Value)).ToString()
+                        Percent = ((int)Math.Round(payParams.MaxFeePercent.Value)).ToString()
                     };
                 }
 
@@ -381,9 +381,9 @@ namespace BTCPayServer.Lightning.LND
             }
         }
 
-        async Task<PayResponse> ILightningClient.Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation)
+        async Task<PayResponse> ILightningClient.Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation)
         {
-            return await PayAsync(bolt11, maxFeePercent, cancellation);
+            return await PayAsync(bolt11, payParams, cancellation);
         }
 
         async Task<PayResponse> ILightningClient.Pay(string bolt11, CancellationToken cancellation)

--- a/src/BTCPayServer.Lightning.LND/LndSwaggerClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndSwaggerClient.cs
@@ -8091,11 +8091,68 @@ namespace BTCPayServer.Lightning.LND
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
+    public partial class LnrpcFeeLimit : System.ComponentModel.INotifyPropertyChanged
+    {
+        private string _fixed;
+        private string _percent;
+
+        /// <summary>/ The fee limit expressed as a fixed amount of satoshis.</summary>
+        [Newtonsoft.Json.JsonProperty("fixed", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Fixed
+        {
+            get { return _fixed; }
+            set
+            {
+                if (_fixed != value)
+                {
+                    _fixed = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>/ The fee limit expressed as a percentage of the payment amount.</summary>
+        [Newtonsoft.Json.JsonProperty("percent", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Percent
+        {
+            get { return _percent; }
+            set
+            {
+                if (_percent != value)
+                {
+                    _percent = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+        public string ToJson()
+        {
+            return Newtonsoft.Json.JsonConvert.SerializeObject(this);
+        }
+
+        public static LnrpcFeeLimit FromJson(string data)
+        {
+            return Newtonsoft.Json.JsonConvert.DeserializeObject<LnrpcFeeLimit>(data);
+        }
+
+        protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
+        {
+            var handler = PropertyChanged;
+            if (handler != null)
+                handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.9.11.0 (Newtonsoft.Json v9.0.0.0)")]
     public partial class LnrpcSendRequest : System.ComponentModel.INotifyPropertyChanged
     {
         private byte[] _dest;
         private string _dest_string;
         private string _amt;
+        private LnrpcFeeLimit _fee_limit;
         private byte[] _payment_hash;
         private string _payment_hash_string;
         private string _payment_request;
@@ -8139,6 +8196,21 @@ namespace BTCPayServer.Lightning.LND
                 if (_amt != value)
                 {
                     _amt = value;
+                    RaisePropertyChanged();
+                }
+            }
+        }
+
+        /// <summary>/ The maximum number of satoshis that will be paid as a fee of the payment. If this field is left to the default value of 0, only zero-fee routes will be considered.</summary>
+        [Newtonsoft.Json.JsonProperty("fee_limit", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public LnrpcFeeLimit Fee_limit
+        {
+            get { return _fee_limit; }
+            set
+            {
+                if (_fee_limit != value)
+                {
+                    _fee_limit = value;
                     RaisePropertyChanged();
                 }
             }

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -74,9 +74,15 @@ namespace BTCPayServer.Lightning.LNbank
 
         public async Task<PayResponse> Pay(string bolt11, CancellationToken cancellation)
         {
+            return await Pay(bolt11, null, cancellation);
+        }
+
+        public async Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation)
+        {
             var payload = new PayInvoiceRequest
             {
-                PaymentRequest = bolt11
+                PaymentRequest = bolt11,
+                MaxFeePercent = maxFeePercent
             };
             return await Post<PayInvoiceRequest, PayResponse>("pay", payload, cancellation);
         }

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -77,12 +77,12 @@ namespace BTCPayServer.Lightning.LNbank
             return await Pay(bolt11, null, cancellation);
         }
 
-        public async Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation)
+        public async Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation)
         {
             var payload = new PayInvoiceRequest
             {
                 PaymentRequest = bolt11,
-                MaxFeePercent = maxFeePercent
+                MaxFeePercent = payParams?.MaxFeePercent
             };
             return await Post<PayInvoiceRequest, PayResponse>("pay", payload, cancellation);
         }

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -106,9 +106,9 @@ namespace BTCPayServer.Lightning.LNbank
             return await _client.Pay(bolt11, cancellation);
         }
 
-        public async Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation = default)
+        public async Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation = default)
         {
-            return await _client.Pay(bolt11, maxFeePercent, cancellation);
+            return await _client.Pay(bolt11, payParams, cancellation);
         }
 
         public async Task<OpenChannelResponse> OpenChannel(OpenChannelRequest req, CancellationToken cancellation = default)

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -106,6 +106,11 @@ namespace BTCPayServer.Lightning.LNbank
             return await _client.Pay(bolt11, cancellation);
         }
 
+        public async Task<PayResponse> Pay(string bolt11, float? maxFeePercent, CancellationToken cancellation = default)
+        {
+            return await _client.Pay(bolt11, maxFeePercent, cancellation);
+        }
+
         public async Task<OpenChannelResponse> OpenChannel(OpenChannelRequest req, CancellationToken cancellation = default)
         {
             OpenChannelResult result;

--- a/src/BTCPayServer.Lightning.LNbank/Models/PayInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/PayInvoiceRequest.cs
@@ -3,5 +3,6 @@ namespace BTCPayServer.Lightning.LNbank.Models
     public class PayInvoiceRequest
     {
         public string PaymentRequest { get; set; }
+        public float? MaxFeePercent { get; set; }
     }
 }

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -245,7 +245,7 @@ namespace BTCPayServer.Lightning.Tests
 					Assert.Equal(amount, paidInvoice.AmountReceived);
 
                     // with max fee percent
-                    paidReply = await test.Customer.Pay(invoiceMaxFee.BOLT11, 6.15f);
+                    paidReply = await test.Customer.Pay(invoiceMaxFee.BOLT11, new PayInvoiceParams { MaxFeePercent = 6.15f });
                     Assert.Equal(PayResult.Ok, paidReply.Result);
                     Assert.Equal(amount, paidReply.Details.TotalAmount);
                     Assert.Equal(0, paidReply.Details.FeeAmount);


### PR DESCRIPTION
Adds `MaxFeePercent` to the `PayInvoiceRequest`, an optional/nullable float property expressing the fee limit as a percentage of the payment amount.

Added for all `ILightningClient` implementations (not supported by Charge though)