### PR TITLE
LNbank: Fix transaction hub URL

### DIFF
--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -79,7 +79,7 @@ namespace BTCPayServer.Lightning.LNbank
 
         public async Task<PayResponse> Pay(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation)
         {
-            
+
             var payload = new PayInvoiceRequest
             {
                 PaymentRequest = bolt11,
@@ -137,7 +137,7 @@ namespace BTCPayServer.Lightning.LNbank
             req.Headers.Accept.Clear();
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiToken);
-            req.Headers.Add("User-Agent", "BTCPayServer.Lightning.LNbankLightningClient");
+            req.Headers.Add("User-Agent", "BTCPayServer.Lightning.LNbankClient");
 
             var res = await _httpClient.SendAsync(req, cancellation);
             var str = await res.Content.ReadAsStringAsync();

--- a/src/BTCPayServer.Lightning.LNbank/LNbankHubClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankHubClient.cs
@@ -18,7 +18,7 @@ namespace BTCPayServer.Lightning.LNbank
             _lightningClient = lightningClient;
             _cancellationToken = cancellation;
             _connection = new HubConnectionBuilder()
-                .WithUrl($"{baseUri.AbsoluteUri}Hubs/Transaction", options => {
+                .WithUrl($"{baseUri.AbsoluteUri}plugins/lnbank/hubs/transaction", options => {
                     options.AccessTokenProvider = () => Task.FromResult(apiToken);
                 })
                 .WithAutomaticReconnect()

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using System.Linq;
 using System.Net.Http;
-using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
 using NBitcoin;
-using Microsoft.AspNetCore.SignalR.Client;
 
 namespace BTCPayServer.Lightning.LNbank
 {


### PR DESCRIPTION
This fixes the transaction hub URL. 

Can you merge and do a new release, @NicolasDorier? I'll then update the Lightning lib in BTCPay and create a new LNbank version.