### PR TITLE
Update CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,16 @@
 version: 2
 jobs:
   build:
-    machine: 
-        enabled: true
-    steps: 
+    machine:
+      enabled: true
+      image: ubuntu-2004:202201-02
+    steps:
       - checkout
 
   test:
     machine:
-        enabled: true
+      enabled: true
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - run:


### PR DESCRIPTION
As in btcpayserver/btcpayserver#3475: CircleCI recently [deprecated build images](https://circleci.com/blog/ubuntu-14-16-image-deprecation/), including the classic ones we are using.