### PR TITLE
C-Lightning: Null-check payment preimage

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -401,7 +401,7 @@ namespace BTCPayServer.Lightning.CLightning
                 Status = ToPaymentStatus(payment.Status),
                 CreatedAt = payment.CreatedAt,
                 PaymentHash = payment.PaymentHash.ToString(),
-                Preimage = payment.Preimage.ToString()
+                Preimage = payment.Preimage?.ToString()
             };
 
         public static LightningInvoiceStatus ToInvoiceStatus(string status)


### PR DESCRIPTION
The property is only set when the status is "complete". [Details](https://lightning.readthedocs.io/lightning-listpays.7.html)