### PR TITLE
Lightning balance: Update responses, support balance check in LNbank

### DIFF
--- a/src/BTCPayServer.Lightning.Common/LightningNodeBalance.cs
+++ b/src/BTCPayServer.Lightning.Common/LightningNodeBalance.cs
@@ -1,9 +1,14 @@
+using Newtonsoft.Json;
+
 namespace BTCPayServer.Lightning
 {
     public class LightningNodeBalance
     {
         public OnchainBalance OnchainBalance { get; set; }
         public OffchainBalance OffchainBalance { get; set; }
+        
+        // parameterless constructor for JSON serialization
+        public LightningNodeBalance() {}
 
         public LightningNodeBalance(OnchainBalance onchain, OffchainBalance offchain)
         {
@@ -14,16 +19,28 @@ namespace BTCPayServer.Lightning
 
     public class OnchainBalance
     {
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Confirmed { get; set; }
+        
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Unconfirmed { get; set; }
+        
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Reserved { get; set; }
     }
 
     public class OffchainBalance
     {
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Opening { get; set; }
+        
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Local { get; set; }
+        
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Remote { get; set; }
+        
+        [JsonConverter(typeof(JsonConverters.LightMoneyJsonConverter))]
         public LightMoney Closing { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
@@ -179,7 +179,7 @@ namespace BTCPayServer.Lightning.Eclair
             { 
                 Confirmed = global.Onchain.Confirmed,
                 Unconfirmed = global.Onchain.Unconfirmed,
-                Reserved = LightMoney.Zero // Not supported by Eclair
+                Reserved = null // Not supported by Eclair
             };
             var offchain = new OffchainBalance
             {

--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -419,7 +419,7 @@ namespace BTCPayServer.Lightning.LND
             { 
                 Confirmed = onchainResponse.Confirmed_balance,
                 Unconfirmed = onchainResponse.Unconfirmed_balance,
-                Reserved = onchainResponse.Locked_balance ?? LightMoney.Zero
+                Reserved = onchainResponse.Locked_balance 
             };
             var offchain = new OffchainBalance
             {

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubLightningClient.cs
@@ -44,18 +44,11 @@ namespace BTCPayServer.Lightning.LndHub
         public async Task<LightningNodeBalance> GetBalance(CancellationToken cancellation = default)
         {
             var balance = await _client.GetBalance(cancellation);
-            var onchain = new OnchainBalance
-            {
-                Confirmed = LightMoney.Zero, Unconfirmed = LightMoney.Zero, Reserved = LightMoney.Zero
-            };
             var offchain = new OffchainBalance
             {
-                Opening = LightMoney.Zero,
-                Local = balance.BtcBalance.AvailableBalance,
-                Remote = LightMoney.Zero,
-                Closing = LightMoney.Zero
+                Local = balance.BtcBalance.AvailableBalance
             };
-            return new LightningNodeBalance(onchain, offchain);
+            return new LightningNodeBalance(null, offchain);
         }
 
         public async Task<BitcoinAddress> GetDepositAddress(CancellationToken cancellation = default)

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -32,6 +32,11 @@ namespace BTCPayServer.Lightning.LNbank
             return await Get<NodeInfoData>("info", cancellation);
         }
 
+        public async Task<LightningNodeBalance> GetBalance(CancellationToken cancellation)
+        {
+            return await Get<LightningNodeBalance>("balance", cancellation);
+        }
+
         public async Task<InvoiceData> GetInvoice(string invoiceId, CancellationToken cancellation)
         {
             return await Get<InvoiceData>($"invoice/{invoiceId}", cancellation);

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -37,9 +37,16 @@ namespace BTCPayServer.Lightning.LNbank
             return nodeInfo;
         }
 
-        public Task<LightningNodeBalance> GetBalance(CancellationToken cancellation = default)
+        public async Task<LightningNodeBalance> GetBalance(CancellationToken cancellation = default)
         {
-            throw new NotSupportedException();
+            try
+            {
+                return await _client.GetBalance(cancellation);
+            }
+            catch (LNbankClient.LNbankApiException)
+            {
+                return null;
+            }
         }
 
         public async Task<LightningInvoice> GetInvoice(string invoiceId, CancellationToken cancellation = default)


### PR DESCRIPTION
- Do not respond with zero amounts if data is not available - send null instead. This will allow for better interpretation on the client side.
- Adds support for checking the balance of a LNbank wallet.