### PR TITLE
Increase feature bits space and add `AMPRequired` and `PaymentMetadata*` features bits

### DIFF
--- a/src/BTCPayServer.Lightning.Common/BOLT11PaymentRequest.cs
+++ b/src/BTCPayServer.Lightning.Common/BOLT11PaymentRequest.cs
@@ -276,7 +276,7 @@ namespace BTCPayServer.Lightning
                         {
                             if (reader.Read())
                             {
-                                features |= (FeatureBits)(1 << i);
+                                features |= (FeatureBits)((long) 1 << i);
                             }
                         }
                         break;

--- a/src/BTCPayServer.Lightning.Common/FeatureBits.cs
+++ b/src/BTCPayServer.Lightning.Common/FeatureBits.cs
@@ -3,7 +3,7 @@ using System;
 namespace BTCPayServer.Lightning
 {
     [Flags]
-    public enum FeatureBits
+    public enum FeatureBits : long
     {
         None = 0,
 

--- a/src/BTCPayServer.Lightning.Common/FeatureBits.cs
+++ b/src/BTCPayServer.Lightning.Common/FeatureBits.cs
@@ -46,6 +46,26 @@ namespace BTCPayServer.Lightning
         /// of a payment supports settlement of an invoice with more than one
         /// HTLC.
         /// </summary>
-        MPPOptional = 1 << 17
+        MPPOptional = 1 << 17,
+
+        /// <summary>
+        // AMPRequired is a required feature bit that signals that the receiver
+        // of a payment supports accepts spontaneous payments
+        /// </summary>
+        AMPRequired = 1 << 30,
+        
+        /// <summary>
+        /// PaymentMetadataRequired is a required bit that denotes that if an
+        /// invoice contains metadata, it must be passed along with the payment
+        /// htlc(s).
+        /// </summary>
+        PaymentMetadataRequired = (long) 1 << 48,
+
+        /// <summary>
+        // PaymentMetadataOptional is an optional bit that denotes that if an
+        // invoice contains metadata, it may be passed along with the payment
+        // htlc(s).
+        /// </summary>
+        PaymentMetadataOptional = (long) 1 << 49
     }
 }

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -658,6 +658,10 @@ retry:
             Assert.True((p.FeatureBits | (FeatureBits.MPPOptional | FeatureBits.PaymentAddrRequired | FeatureBits.TLVOnionPayloadOptional)) ==
                 (FeatureBits.MPPOptional | FeatureBits.PaymentAddrRequired | FeatureBits.TLVOnionPayloadOptional));
             Assert.True(p.VerifySignature());
+            
+            p = BOLT11PaymentRequest.Parse("lnbcrt1p3w0278pp5n8ky9m98m7ppjw4gr4mhgvxhm8r0830w870raccvu6tgnavrs60sdqqcqzpgxqyz5vqsp5v50decplk2phztne8xqjxyvrrr2k0nf2q5sflnn4vqc6mc048fds9q2gqqqqqyssqk6tlvhclzm7ejg6p8szg34tt28puz5hvmuv93rkhnaq63t6k92sk0q2g7arltwqahvhg3ks6l922zsdtnf7wt540ypmqqulzvke8gyqqttv7fu", Network.RegTest);
+            Assert.True((p.FeatureBits | (FeatureBits.MPPOptional | FeatureBits.PaymentAddrRequired | FeatureBits.TLVOnionPayloadOptional | FeatureBits.PaymentMetadataRequired)) == 
+                        (FeatureBits.MPPOptional | FeatureBits.PaymentAddrRequired | FeatureBits.TLVOnionPayloadOptional | FeatureBits.PaymentMetadataRequired));
 
             p = BOLT11PaymentRequest.Parse("lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp", Network.Main);
             Assert.Equal("lnbc", p.Prefix);


### PR DESCRIPTION
The feature bits for  `PaymentMetadata` that have been formally accepted into the bolt specification would currently result in an overflow when parsing and hence set unrelated feature bits. This PR therefore changes the backing of the enum `FeatureBits` to Int64 to allow for more enums to be represented and adds this feature bits and a test case for it.

Additionally this PR adds the not yet formalized `AMPRequired` feature bits used by LND. Note that even without changing the backing to Int64 for the feature bits this does _not_ overflow, as that is the highest enum value representable currently. I hope it is in the interest of adding this feature bits in parsing invoices as those may be encountered in real-world already even though it is not formalized yet.

Note that a more future proof solution would probably be to use e.g. BitArrays for the FeatureBits, as the backing for Int64 will also run out eventually and unexpectedly.