### PR TITLE
Connection string updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,13 @@ LightningInvoice invoice = await client.CreateInvoice(10000, "CanCreateInvoice",
 
 `ILightningClient` is an interface which abstract the underlying implementation with a common interface.
 
-The `connectionString` encapsulates the necessary information BTCPay needs to connect to your lightning node, we currently support:
+The `connectionString` encapsulates the necessary information BTCPay needs to connect to your Lightning node, we currently support:
 
 * `clightning` via TCP or unix domain socket connection
 * `lightning charge` via HTTPS
 * `LND` via the REST proxy
 * `Eclair` via their new REST API
+* `LNbank` via REST API
 * `LNDhub` via their REST API
 
 #### Examples
@@ -76,12 +77,17 @@ The `connectionString` encapsulates the necessary information BTCPay needs to co
 * `type=charge;server=https://charge:8080/;api-token=myapitoken...`
 * `type=charge;server=https://charge:8080/;cookiefilepath=/path/to/cookie...`
 * `type=eclair;server=http://127.0.0.1:4570;password=eclairpass`
+* `type=eclair;server=http://127.0.0.1:4570;password=eclairpass;bitcoin-host=bitcoin.host;bitcoin-auth=btcpass`
 * `type=lnbank;server=http://lnbank:5000;api-token=myapitoken;allowinsecure=true`
 * `type=lnbank;server=https://mybtcpay.com/lnbank;api-token=myapitoken`
 * `type=lndhub;server=https://login:password@lndhub.io`
 
+##### Eclair notes
+
 Note that `bitcoin-host` and `bitcoin-auth` are optional, only useful if you want to call `ILightningClient.GetDepositAddress` on Eclair.
 We expect this won't be needed in the future.
+
+##### LND notes
 
 Note that the `certthumbprint` to connect to your LND node can be obtained through this command line:
 
@@ -92,6 +98,11 @@ openssl x509 -noout -fingerprint -sha256 -in /root/.lnd/tls.cert | sed -e 's/.*=
 You can omit `certthumprint` if you the certificate is trusted by your machine
 
 You can set `allowinsecure` to `true` if your LND REST server is using HTTP or HTTPS with an untrusted certificate which you don't know the `certthumprint`.
+
+##### LNDhub notes
+
+You can also use the `lndhub://` URL, which can be retrieved e.g. from the BlueWallet Export/Backup screen.
+The library turns it into the expected `type=lndhub` connection string format.
 
 ### Using implementation specific class
 
@@ -106,7 +117,7 @@ cd tests
 docker-compose up
 ```
 
-Then you can run and debug the tests with visual studio or visual studio code.
+Then you can run and debug the tests with Visual Studio or Visual Studio Code.
 
 If you want to use command line:
 

--- a/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
+++ b/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
@@ -654,6 +654,13 @@ namespace BTCPayServer.Lightning
                         builder.Append(";allowinsecure=true");
                     }
                     break;
+                case LightningConnectionType.LNDhub:
+                    builder.Append($";server={BaseUri}");
+                    if (AllowInsecure)
+                    {
+                        builder.Append(";allowinsecure=true");
+                    }
+                    break;
                 default:
                     throw new NotSupportedException(type);
             }

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -175,6 +175,11 @@ namespace BTCPayServer.Lightning.Tests
             var clientTypes = Tester.GetLightningClients().Select(l => l.Client.GetType()).ToArray();
             foreach (var connectionString in connectionStrings)
             {
+                // check connection string can be parsed and turned into a string again
+                LightningConnectionString.TryParse(connectionString, false, out var parsed);
+                Assert.NotNull(parsed.ToString());
+                
+                // apply connection string and create invoice   
                 var client = factory.Create(connectionString);
                 if (!clientTypes.Contains(client.GetType())) continue;
                 

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -189,6 +189,30 @@ namespace BTCPayServer.Lightning.Tests
                 AssertUnpaid(retrievedInvoice);
             }
         }
+        
+        [Fact]
+        public void CanParseCustomConnectionString()
+        {
+            var network = Tester.Network;
+            ILightningClientFactory factory = new LightningClientFactory(network);
+                
+            var connectionStrings = new List<string>
+                {
+                    "lndhub://login:password@http://server.onion"
+                };
+            
+            var clientTypes = Tester.GetLightningClients().Select(l => l.Client.GetType()).ToArray();
+            foreach (var connectionString in connectionStrings)
+            {
+                // check connection string can be parsed and turned into a string again
+                LightningConnectionString.TryParse(connectionString, false, out var parsed);
+                Assert.NotNull(parsed.ToString());
+                
+                // apply connection string and check client
+                var client = factory.Create(connectionString);
+                Assert.Contains(client.GetType(), clientTypes);
+            }
+        }
 
         [Fact(Timeout = Timeout)]
         public async Task CanGetInfo()


### PR DESCRIPTION
Fixes the missing LNDhub connection type in the `ToString` method and adds parsing for `lndhub://` URLs, so that we don't have to explain how to convert it to the connection string format.

Also adds that additional information to the README.