### PR TITLE
Support certificate file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The `connectionString` encapsulates the necessary information BTCPay needs to co
 * `type=lnd-rest;server=http://mylnd:8080/;macaroonfilepath=/root/.lnd/admin.macaroon;allowinsecure=true`
 * `type=lnd-rest;server=https://mylnd:8080/;macaroon=abef263adfe...`
 * `type=lnd-rest;server=https://mylnd:8080/;macaroon=abef263adfe...;certthumbprint=abef263adfe...`
+* `type=lnd-rest;server=https://mylnd:8080/;macaroonfilepath=/root/.lnd/admin.macaroon;certfilepath=/var/lib/lnd/tls.cert`
 * `type=charge;server=https://charge:8080/;api-token=myapitoken...`
 * `type=charge;server=https://charge:8080/;cookiefilepath=/path/to/cookie...`
 * `type=eclair;server=http://127.0.0.1:4570;password=eclairpass`
@@ -89,15 +90,21 @@ We expect this won't be needed in the future.
 
 ##### LND notes
 
-Note that the `certthumbprint` to connect to your LND node can be obtained through this command line:
+Unless the LND certificate is trusted by your machine you need to set the server authentication scheme for LND by specifying one of: `certthumbprint`, `certfilepath`, `allowinsecure=true`.
+
+`certfilepath` and `certthumbprint` are equivalent in terms of security but differ in their practical usage.
+`certfilepath` reads a file on your file system so unless you set up some kind of file syncing you can not use it for remote connections.
+The advantage is that if the certificate is updated (and synced in case of a remote machine) no more reconfiguration is required for RPC connections to continue to work.
+It is therefore the recommended option if you can use it.
+
+The `certthumbprint` to connect to your LND node can be obtained through this command line:
 
 ```bash
 openssl x509 -noout -fingerprint -sha256 -in /root/.lnd/tls.cert | sed -e 's/.*=//;s/://g'
 ```
 
-You can omit `certthumprint` if you the certificate is trusted by your machine
-
-You can set `allowinsecure` to `true` if your LND REST server is using HTTP or HTTPS with an untrusted certificate which you don't know the `certthumprint`.
+`allowinsecure=true` just blindly accepts any server connection and is therefore not secure unless used in tightly controlled environments.
+E.g. host is the same machine or is accessed over an encrypted tunnel, assuming no untrusted entities can bind the specified port.
 
 ##### LNDhub notes
 

--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net6.0</TargetFramework>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
 		<Version>1.4.0</Version>
-		<LangVersion>7.3</LangVersion>
+		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.All</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>
 		<PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
-		<Version>1.3.13</Version>
+		<Version>1.4.0</Version>
 		<LangVersion>7.3</LangVersion>
 		<PackageId>BTCPayServer.Lightning.All</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
+++ b/src/BTCPayServer.Lightning.All/LightningClientFactory.cs
@@ -64,6 +64,7 @@ namespace BTCPayServer.Lightning
                     Macaroon = connectionString.Macaroon,
                     MacaroonFilePath = connectionString.MacaroonFilePath,
                     CertificateThumbprint = connectionString.CertificateThumbprint,
+                    CertificateFilePath = connectionString.CertificateFilePath,
                     AllowInsecure = connectionString.AllowInsecure,
                 }, HttpClient), Network);
             }

--- a/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
+++ b/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
@@ -295,6 +295,17 @@ namespace BTCPayServer.Lightning
                             securitySet = "certthumbprint";
                         }
 
+                        var certificateFilePath = Take(keyValues, "certfilepath");
+                        if (certificateFilePath != null)
+                        {
+                            if (securitySet != null) {
+                                error = $"The key 'certfilepath' conflict with '{securitySet}'";
+                                return false;
+                            }
+                            result.CertificateFilePath = certificateFilePath;
+                            securitySet = "certfilepath";
+                        }
+
                         var allowinsecureStr = Take(keyValues, "allowinsecure");
 
                         if (allowinsecureStr != null)
@@ -563,6 +574,7 @@ namespace BTCPayServer.Lightning
         }
         public byte[] Macaroon { get; set; }
         public string MacaroonFilePath { get; set; }
+        public string CertificateFilePath { get; set; }
         public byte[] CertificateThumbprint { get; set; }
         public bool AllowInsecure { get; set; }
         public string CookieFilePath { get; set; }

--- a/src/BTCPayServer.Lightning.CLightning/BTCPayServer.Lightning.CLightning.csproj
+++ b/src/BTCPayServer.Lightning.CLightning/BTCPayServer.Lightning.CLightning.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	  <Version>1.3.9</Version>
-	  <LangVersion>7.3</LangVersion>
+	  <LangVersion>10</LangVersion>
 	  <PackageId>BTCPayServer.Lightning.CLightning</PackageId>
 	  <Description>Client library for c-lightning to build Lightning Network Apps in C#.</Description>
 	  <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.Charge/BTCPayServer.Lightning.Charge.csproj
+++ b/src/BTCPayServer.Lightning.Charge/BTCPayServer.Lightning.Charge.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 	  <Version>1.3.8</Version>
-	  <LangVersion>7.3</LangVersion>
+	  <LangVersion>10</LangVersion>
 	  <PackageId>BTCPayServer.Lightning.Charge</PackageId>
 	  <Description>Client library for lightning charge to build Lightning Network Apps in C#.</Description>
 	  <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.Common/BTCPayServer.Lightning.Common.csproj
+++ b/src/BTCPayServer.Lightning.Common/BTCPayServer.Lightning.Common.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0</TargetFrameworks>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
 		<Version>1.3.8</Version>
-		<LangVersion>8.0</LangVersion>
+		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.Common</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>
 		<PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageTags>lightning;bitcoin;clightning;lnd;charge;lapps</PackageTags>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/BTCPayServer.Lightning.Eclair/BTCPayServer.Lightning.Eclair.csproj
+++ b/src/BTCPayServer.Lightning.Eclair/BTCPayServer.Lightning.Eclair.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>1.3.8</Version>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>10</LangVersion>
     <PackageId>BTCPayServer.Lightning.Eclair</PackageId>
     <Description>Client library for Eclair to build Lightning Network Apps in C#.</Description>
     <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
+++ b/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
 		<Version>1.4.0</Version>
-		<LangVersion>8.0</LangVersion>
+		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.LND</PackageId>
 		<Description>Client library for LND to build Lightning Network Apps in C#.</Description>
 		<PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
+++ b/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
-		<Version>1.3.9</Version>
+		<TargetFramework>net6.0</TargetFramework>
+		<Version>1.4.0</Version>
 		<LangVersion>8.0</LangVersion>
 		<PackageId>BTCPayServer.Lightning.LND</PackageId>
 		<Description>Client library for LND to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.LND/LndRestSettings.cs
+++ b/src/BTCPayServer.Lightning.LND/LndRestSettings.cs
@@ -20,6 +20,7 @@ namespace BTCPayServer.Lightning.LND
         /// The SHA256 of the PEM certificate
         /// </summary>
         public byte[] CertificateThumbprint { get; set; }
+        public string CertificateFilePath { get; set; }
         public byte[] Macaroon { get; set; }
         public bool AllowInsecure { get; set; }
         public string MacaroonFilePath { get; set; }

--- a/src/BTCPayServer.Lightning.LNDhub/BTCPayServer.Lightning.LNDhub.csproj
+++ b/src/BTCPayServer.Lightning.LNDhub/BTCPayServer.Lightning.LNDhub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Version>1.0.3</Version>
         <PackageId>BTCPayServer.Lightning.LNDhub</PackageId>
         <Description>Client library for BlueWallet LNDhub to build Lightning Network Apps in C#.</Description>
@@ -9,7 +9,7 @@
         <RepositoryUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</RepositoryUrl>
         <PackageTags>lightning;bitcoin;lndhub;lapps</PackageTags>
         <OutputType>Library</OutputType>
-        <LangVersion>8.0</LangVersion>
+        <LangVersion>10</LangVersion>
     	<PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
 

--- a/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
+++ b/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Version>1.3.10</Version>
         <PackageId>BTCPayServer.Lightning.LNBank</PackageId>
         <Description>Client library for LNBank to build Lightning Network Apps in C#.</Description>
@@ -9,6 +9,7 @@
         <RepositoryUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageTags>lightning;bitcoin;lnbank;lapps</PackageTags>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/BTCPayServer.Lightning.Tests.csproj
+++ b/tests/BTCPayServer.Lightning.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
-	  <LangVersion>8</LangVersion>
+	  <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/BTCPayServer.Lightning.Tests.csproj
+++ b/tests/BTCPayServer.Lightning.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 	  <LangVersion>8</LangVersion>

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100-alpine3.10 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:6.0.400-1-alpine3.16 AS builder
 
 ENV IN_DOCKER_CONTAINER true
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT false


### PR DESCRIPTION
When the LND certificate expires or changes because of added hosts the
certthumbprint changes and is not updated automatically, forcing users
to update the configuration.  workaround is is to allow insecure
connections but that is obviously not secure.

This change adds a new configuration option `certfilepath` to set the
path of the certificate. The certificate located at that path is loaded
at each attempt to connect to LND and checked to contain server-supplied
certificate. If it's present the connection is accepted.

This is required for resolving
https://github.com/btcpayserver/btcpayserver/issues/2182

This raises required dotnet version, I guess it's OK since BTCPayServer raised it too.