### PR TITLE
Add custom TLV records to invoice

### DIFF
--- a/src/BTCPayServer.Lightning.Common/LightningInvoice.cs
+++ b/src/BTCPayServer.Lightning.Common/LightningInvoice.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace BTCPayServer.Lightning
 {
@@ -11,5 +12,6 @@ namespace BTCPayServer.Lightning
         public DateTimeOffset ExpiresAt { get; set; }
         public LightMoney Amount { get; set; }
         public LightMoney AmountReceived { get; set; }
+        public Dictionary<ulong, string> CustomRecords { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.Common/LightningInvoice.cs
+++ b/src/BTCPayServer.Lightning.Common/LightningInvoice.cs
@@ -1,17 +1,16 @@
 using System;
 using System.Collections.Generic;
 
-namespace BTCPayServer.Lightning
+namespace BTCPayServer.Lightning;
+
+public class LightningInvoice
 {
-    public class LightningInvoice
-    {
-        public string Id { get; set; }
-        public LightningInvoiceStatus Status { get; set; }
-        public string BOLT11 { get; set; }
-        public DateTimeOffset? PaidAt { get; set; }
-        public DateTimeOffset ExpiresAt { get; set; }
-        public LightMoney Amount { get; set; }
-        public LightMoney AmountReceived { get; set; }
-        public Dictionary<ulong, string> CustomRecords { get; set; }
-    }
+    public string Id { get; set; }
+    public LightningInvoiceStatus Status { get; set; }
+    public string BOLT11 { get; set; }
+    public DateTimeOffset? PaidAt { get; set; }
+    public DateTimeOffset ExpiresAt { get; set; }
+    public LightMoney Amount { get; set; }
+    public LightMoney AmountReceived { get; set; }
+    public Dictionary<ulong, string> CustomRecords { get; set; }
 }

--- a/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
@@ -2,18 +2,17 @@
 using System.Collections.Generic;
 using NBitcoin;
 
-namespace BTCPayServer.Lightning
+namespace BTCPayServer.Lightning;
+
+public class PayInvoiceParams
 {
-    public class PayInvoiceParams
-    {
-        public double? MaxFeePercent { get; set; }
-        public Money? MaxFeeFlat { get; set; }
-        public LightMoney? Amount { get; set; }
-        
-        public PubKey? Destination { get; set; }
-        
-        public uint256? PaymentHash { get; set; }
-        
-        public Dictionary<ulong,string>? CustomRecords { get; set; }
-    }
+    public double? MaxFeePercent { get; set; }
+    public Money? MaxFeeFlat { get; set; }
+    public LightMoney? Amount { get; set; }
+
+    public PubKey? Destination { get; set; }
+
+    public uint256? PaymentHash { get; set; }
+
+    public Dictionary<ulong, string>? CustomRecords { get; set; }
 }

--- a/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
@@ -10,10 +10,10 @@ namespace BTCPayServer.Lightning
         public Money? MaxFeeFlat { get; set; }
         public LightMoney? Amount { get; set; }
         
-        public PubKey Destination { get; set; }
+        public PubKey? Destination { get; set; }
         
-        public uint256 PaymentHash { get; set; }
+        public uint256? PaymentHash { get; set; }
         
-        public Dictionary<ulong,string> CustomRecords { get; set; }
+        public Dictionary<ulong,string>? CustomRecords { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -488,10 +488,17 @@ namespace BTCPayServer.Lightning.LND
                 Status = LightningInvoiceStatus.Unpaid,
                 ExpiresAt = DateTimeOffset.FromUnixTimeSeconds(ConvertInv.ToInt64(resp.Creation_date) + ConvertInv.ToInt64(resp.Expiry))
             };
+
+            if (resp.Htlcs != null && resp.Htlcs.Any())
+            {
+                invoice.CustomRecords = resp.Htlcs
+                    .SelectMany(htlc => htlc.CustomRecords)
+                    .ToDictionary(x => x.Key, y => y.Value);
+            }
+            
             if (resp.Settled == true)
             {
                 invoice.PaidAt = DateTimeOffset.FromUnixTimeSeconds(ConvertInv.ToInt64(resp.Settle_date));
-
                 invoice.Status = LightningInvoiceStatus.Paid;
             }
             else

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -359,11 +359,14 @@ namespace BTCPayServer.Lightning.Tests
                 var paymentHash = new uint256(Hashes.SHA256(preimage));
 
                 // https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md
+                var val5482373484 = Encoders.Base64.EncodeData(preimage);
+                var val696969 = Encoders.Base64.EncodeData(Encoding.Default.GetBytes("123456"));
+                var val112111100 = Encoders.Base64.EncodeData(Encoding.Default.GetBytes("wal_hrDHs0RBEM576"));
                 var tlvData = new Dictionary<ulong,string>
                 {
-                    { 5482373484, Encoders.Base64.EncodeData(preimage) },
-                    { 696969, Encoders.Base64.EncodeData(Encoding.Default.GetBytes("123456")) },
-                    { 112111100, Encoders.Base64.EncodeData(Encoding.Default.GetBytes("wal_hrDHs0RBEM576")) }
+                    { 696969, val696969 },
+                    { 112111100, val112111100 },
+                    { 5482373484, val5482373484 }
                 };
                 var param = new PayInvoiceParams
                 {
@@ -393,6 +396,19 @@ namespace BTCPayServer.Lightning.Tests
                             await src.Pay(param);
                         });
                         break;
+                }
+                
+                // Check the custom records are present in the invoice
+                // Only works for LND right now, Core Lightning support might come, see:
+                // https://github.com/ElementsProject/lightning/issues/4470#issuecomment-873599548
+                if (src is LndClient)
+                {
+                    var invoiceId = Encoders.Hex.EncodeData(paymentHash.ToBytes());
+                    var invoice = await dest.GetInvoice(invoiceId);
+                    Assert.NotNull(invoice.CustomRecords);
+                    Assert.Contains(invoice.CustomRecords, pair => pair.Key == 696969 && pair.Value == val696969);
+                    Assert.Contains(invoice.CustomRecords, pair => pair.Key == 112111100 && pair.Value == val112111100);
+                    Assert.Contains(invoice.CustomRecords, pair => pair.Key == 5482373484 && pair.Value == val5482373484);
                 }
             }
         }


### PR DESCRIPTION
Builds on the keysend feature added in #96.

Custom [TLV records](https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md) only work for LND right now, Core Lightning support might come, see ElementsProject/lightning#4470