### PR TITLE
LNDhub: Fix JSON conversion

### DIFF
--- a/src/BTCPayServer.Lightning.LNDhub/JsonConverters/LndHubLightMoneyJsonConverter.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/JsonConverters/LndHubLightMoneyJsonConverter.cs
@@ -37,7 +37,7 @@ namespace BTCPayServer.Lightning.LNDhub.JsonConverters
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             if (value != null)
-                writer.WriteValue((int)((LightMoney)value).ToUnit(LightMoneyUnit.Satoshi));
+                writer.WriteValue(((LightMoney)value).ToUnit(LightMoneyUnit.Satoshi));
             else
                 writer.WriteNull();
         }


### PR DESCRIPTION
Fixes the exception `System.OverflowException: Value was either too large or too small for an Int32.`