### PR TITLE
LND/CLN: Timeout payments and respond gracefully

### DIFF
--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
-		<Version>1.4.7</Version>
+		<Version>1.4.8</Version>
 		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.All</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.CLightning/BTCPayServer.Lightning.CLightning.csproj
+++ b/src/BTCPayServer.Lightning.CLightning/BTCPayServer.Lightning.CLightning.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-	  <Version>1.3.15</Version>
+	  <Version>1.3.16</Version>
 	  <LangVersion>10</LangVersion>
 	  <PackageId>BTCPayServer.Lightning.CLightning</PackageId>
 	  <Description>Client library for c-lightning to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -294,7 +294,8 @@ namespace BTCPayServer.Lightning.CLightning
                 
             // Pay the invoice - cancel after timeout, potentially caused by hold invoices
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
-            cts.CancelAfter(LightningPayment.SendTimeout);
+            var timeout = payParams?.SendTimeout ?? TimeSpan.FromSeconds(30);
+            cts.CancelAfter(timeout);
             
             try
             {

--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -294,7 +294,7 @@ namespace BTCPayServer.Lightning.CLightning
                 
             // Pay the invoice - cancel after timeout, potentially caused by hold invoices
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
-            var timeout = payParams?.SendTimeout ?? TimeSpan.FromSeconds(30);
+            var timeout = payParams?.SendTimeout ?? PayInvoiceParams.DefaultSendTimeout;
             cts.CancelAfter(timeout);
             
             try

--- a/src/BTCPayServer.Lightning.Charge/BTCPayServer.Lightning.Charge.csproj
+++ b/src/BTCPayServer.Lightning.Charge/BTCPayServer.Lightning.Charge.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-	  <Version>1.3.13</Version>
+	  <Version>1.3.14</Version>
 	  <LangVersion>10</LangVersion>
 	  <PackageId>BTCPayServer.Lightning.Charge</PackageId>
 	  <Description>Client library for lightning charge to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.Common/BTCPayServer.Lightning.Common.csproj
+++ b/src/BTCPayServer.Lightning.Common/BTCPayServer.Lightning.Common.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
-		<Version>1.3.14</Version>
+		<Version>1.3.15</Version>
 		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.Common</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.Common/LightningPayment.cs
+++ b/src/BTCPayServer.Lightning.Common/LightningPayment.cs
@@ -4,8 +4,6 @@ namespace BTCPayServer.Lightning
 {
     public class LightningPayment
     {
-        public static readonly TimeSpan SendTimeout = TimeSpan.FromSeconds(30);
-        
         public string Id { get; set; }
         public string PaymentHash { get; set; }
         public string Preimage { get; set; }

--- a/src/BTCPayServer.Lightning.Common/LightningPayment.cs
+++ b/src/BTCPayServer.Lightning.Common/LightningPayment.cs
@@ -4,6 +4,8 @@ namespace BTCPayServer.Lightning
 {
     public class LightningPayment
     {
+        public static readonly TimeSpan SendTimeout = TimeSpan.FromSeconds(30);
+        
         public string Id { get; set; }
         public string PaymentHash { get; set; }
         public string Preimage { get; set; }

--- a/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
@@ -17,5 +17,6 @@ public class PayInvoiceParams
 
     public Dictionary<ulong, string>? CustomRecords { get; set; }
     
-    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+    public TimeSpan? SendTimeout { get; set; }
+    public static TimeSpan DefaultSendTimeout = TimeSpan.FromSeconds(30.0);
 }

--- a/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/PayInvoiceParams.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using NBitcoin;
 
@@ -15,4 +16,6 @@ public class PayInvoiceParams
     public uint256? PaymentHash { get; set; }
 
     public Dictionary<ulong, string>? CustomRecords { get; set; }
+    
+    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/src/BTCPayServer.Lightning.Common/PayResponse.cs
+++ b/src/BTCPayServer.Lightning.Common/PayResponse.cs
@@ -5,6 +5,7 @@ namespace BTCPayServer.Lightning
     public enum PayResult
     {
         Ok,
+        Unknown,
         CouldNotFindRoute,
         Error
     }

--- a/src/BTCPayServer.Lightning.Eclair/BTCPayServer.Lightning.Eclair.csproj
+++ b/src/BTCPayServer.Lightning.Eclair/BTCPayServer.Lightning.Eclair.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-    <Version>1.3.13</Version>
+    <Version>1.3.14</Version>
     <LangVersion>10</LangVersion>
     <PackageId>BTCPayServer.Lightning.Eclair</PackageId>
     <Description>Client library for Eclair to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
+++ b/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-		<Version>1.4.5</Version>
+		<Version>1.4.6</Version>
 		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.LND</PackageId>
 		<Description>Client library for LND to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -571,7 +571,7 @@ namespace BTCPayServer.Lightning.LND
         {
             // Pay the invoice - cancel after timeout, potentially caused by hold invoices
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
-            var timeout = payParams?.SendTimeout ?? TimeSpan.FromSeconds(30);
+            var timeout = payParams?.SendTimeout ?? PayInvoiceParams.DefaultSendTimeout;
             cts.CancelAfter(timeout);
             
 retry:

--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -571,7 +571,8 @@ namespace BTCPayServer.Lightning.LND
         {
             // Pay the invoice - cancel after timeout, potentially caused by hold invoices
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
-            cts.CancelAfter(LightningPayment.SendTimeout);
+            var timeout = payParams?.SendTimeout ?? TimeSpan.FromSeconds(30);
+            cts.CancelAfter(timeout);
             
 retry:
             var retryCount = 0;

--- a/src/BTCPayServer.Lightning.LNDhub/BTCPayServer.Lightning.LNDhub.csproj
+++ b/src/BTCPayServer.Lightning.LNDhub/BTCPayServer.Lightning.LNDhub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-        <Version>1.0.9</Version>
+        <Version>1.0.10</Version>
         <PackageId>BTCPayServer.Lightning.LNDhub</PackageId>
         <Description>Client library for BlueWallet LNDhub to build Lightning Network Apps in C#.</Description>
         <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
+++ b/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-        <Version>1.3.15</Version>
+        <Version>1.3.16</Version>
         <PackageId>BTCPayServer.Lightning.LNBank</PackageId>
         <Description>Client library for LNBank to build Lightning Network Apps in C#.</Description>
         <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>


### PR DESCRIPTION
Times out invoice payments after 30 seconds and returns the new `PayResult.Unknown` in those cases.

Clients like the Greenfield API can then call/poll `GetPayment` to get the state and result for pending payments.

Here is what an in-flight payment response from the Greenfield API will look like — I can send a PR for the required changes once this PR is merged, because it required the added `PayResult.Unknown`:

![grafik](https://user-images.githubusercontent.com/886/198377552-15539dc3-2474-4487-ab0c-23a77a33b776.png)

For context see [this comment](https://github.com/btcpayserver/btcpayserver/issues/3781#issuecomment-1293446246).