### PR TITLE
Bumping LND to 0.15.4-beta-1

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -108,7 +108,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.15.3-beta
+    image: btcpayserver/lnd:v0.15.4-beta-1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -143,7 +143,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.15.3-beta
+    image: btcpayserver/lnd:v0.15.4-beta-1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.15.4-beta-1/images/sha256-cadbbff93cf36146e24fa4f32170b4b9d278a2e1acfdc50470790a94506ee9c3?context=explore