### PR TITLE
Introduce CreateInvoiceParams.DescriptionHashOnly

### DIFF
--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
-		<Version>1.4.11</Version>
+		<Version>1.4.12</Version>
 		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.All</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.All/ConnectChannels.cs
+++ b/src/BTCPayServer.Lightning.All/ConnectChannels.cs
@@ -139,7 +139,7 @@ namespace BTCPayServer.Lightning.Tests
 
         private static async Task<PayResponse> Pay(ILightningClient sender, string payreq)
         {
-            using (var cts = new CancellationTokenSource(5000))
+            using (var cts = new CancellationTokenSource(30_000))
             {
 retry:
                 try

--- a/src/BTCPayServer.Lightning.CLightning/BTCPayServer.Lightning.CLightning.csproj
+++ b/src/BTCPayServer.Lightning.CLightning/BTCPayServer.Lightning.CLightning.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-	  <Version>1.3.18</Version>
+	  <Version>1.3.19</Version>
 	  <LangVersion>10</LangVersion>
 	  <PackageId>BTCPayServer.Lightning.CLightning</PackageId>
 	  <Description>Client library for c-lightning to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.Charge/BTCPayServer.Lightning.Charge.csproj
+++ b/src/BTCPayServer.Lightning.Charge/BTCPayServer.Lightning.Charge.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-	  <Version>1.3.15</Version>
+	  <Version>1.3.16</Version>
 	  <LangVersion>10</LangVersion>
 	  <PackageId>BTCPayServer.Lightning.Charge</PackageId>
 	  <Description>Client library for lightning charge to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.Charge/ChargeClient.cs
+++ b/src/BTCPayServer.Lightning.Charge/ChargeClient.cs
@@ -219,7 +219,7 @@ namespace BTCPayServer.Lightning.Charge
         }
         Task<LightningInvoice> ILightningClient.CreateInvoice(CreateInvoiceParams req, CancellationToken cancellation)
         {
-            if (req.DescriptionHash != null)
+            if (req.DescriptionHash is not null)
             {
                 throw new NotSupportedException("Lightning Charge does not support creating an invoice with description_hash");
             }

--- a/src/BTCPayServer.Lightning.Common/BTCPayServer.Lightning.Common.csproj
+++ b/src/BTCPayServer.Lightning.Common/BTCPayServer.Lightning.Common.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
-		<Version>1.3.16</Version>
+		<Version>1.3.17</Version>
 		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.Common</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.Common/CreateInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/CreateInvoiceParams.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NBitcoin;
+using NBitcoin.Crypto;
 
 namespace BTCPayServer.Lightning
 {
@@ -20,6 +21,7 @@ namespace BTCPayServer.Lightning
             Description = description;
             Expiry = expiry;
         }
+        [Obsolete("Set the Description and turn DescriptionHashOnly to true instead")]
         public CreateInvoiceParams(LightMoney amount, uint256 descriptionHash, TimeSpan expiry)
         {
             if (amount == null)
@@ -34,7 +36,22 @@ namespace BTCPayServer.Lightning
 
         public LightMoney Amount { get; set; }
         public string Description { get; set; }
-        public uint256 DescriptionHash { get; set; }
+        uint256 _DescriptionHash;
+        public uint256 DescriptionHash
+        {
+            get
+            {
+                if (_DescriptionHash is null && (Description is null || !DescriptionHashOnly))
+                    return null;
+                return _DescriptionHash ?? new uint256(Hashes.SHA256(Encoding.UTF8.GetBytes(Description)), false);
+            }
+            [Obsolete("Set the Description and turn DescriptionHashOnly to true instead")]
+            set
+            {
+                _DescriptionHash = value;
+            }
+        }
+        public bool DescriptionHashOnly { get; set; }
         public TimeSpan Expiry { get; set; }
         public bool PrivateRouteHints { get; set; }
     }

--- a/src/BTCPayServer.Lightning.Eclair/BTCPayServer.Lightning.Eclair.csproj
+++ b/src/BTCPayServer.Lightning.Eclair/BTCPayServer.Lightning.Eclair.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-    <Version>1.3.15</Version>
+    <Version>1.3.16</Version>
     <LangVersion>10</LangVersion>
     <PackageId>BTCPayServer.Lightning.Eclair</PackageId>
     <Description>Client library for Eclair to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
@@ -167,9 +167,9 @@ namespace BTCPayServer.Lightning.Eclair
         }
         Task<LightningInvoice> ILightningClient.CreateInvoice(CreateInvoiceParams req, CancellationToken cancellation)
         {
-            if (req.DescriptionHash != null)
+            if (req.DescriptionHash is not null)
             {
-                throw new NotSupportedException();
+                throw new NotSupportedException("DescriptionHash isn't supported");
             }
             return (this as ILightningClient).CreateInvoice(req.Amount, req.Description, req.Expiry, cancellation);
         }

--- a/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
+++ b/src/BTCPayServer.Lightning.LND/BTCPayServer.Lightning.LND.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-		<Version>1.4.8</Version>
+		<Version>1.4.9</Version>
 		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.LND</PackageId>
 		<Description>Client library for LND to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.LNDhub/BTCPayServer.Lightning.LNDhub.csproj
+++ b/src/BTCPayServer.Lightning.LNDhub/BTCPayServer.Lightning.LNDhub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-        <Version>1.0.11</Version>
+        <Version>1.0.12</Version>
         <PackageId>BTCPayServer.Lightning.LNDhub</PackageId>
         <Description>Client library for BlueWallet LNDhub to build Lightning Network Apps in C#.</Description>
         <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
+++ b/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-        <Version>1.3.17</Version>
+        <Version>1.3.18</Version>
         <PackageId>BTCPayServer.Lightning.LNBank</PackageId>
         <Description>Client library for LNBank to build Lightning Network Apps in C#.</Description>
         <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -47,6 +47,7 @@ services:
         log-level=debug
         dev-fast-gossip
         dev-bitcoind-poll=1
+        database-upgrade=true
     ports:
       - "48532:9835" # api port
     expose:
@@ -74,6 +75,7 @@ services:
         log-level=debug
         dev-fast-gossip
         dev-bitcoind-poll=1
+        database-upgrade=true
     ports:
       - "42549:9835" # api port
     expose:


### PR DESCRIPTION
Before this PR, users of `CreateInvoiceParams` who wanted the `DescriptionHash` in the BOLT11 needed to pass the hash to `CreateInvoiceParams.DescriptionHash`.

The problem with this was that:
1. Core lightning require the `Description` to natively create BOLT11 invoices with description hash. It was not provided before by users.
2. Users need to care about the endianness and shoot themselves in the foot. (we actually did in the tests)

I refactored the `CLIghtningClient.CreateInvoice` to be smart enough to work on the native Core lightning 22.11 API, but also fallback on the `invoicewithdescriptionhash` plugin if that is not possible.

I manually tested that the client still worked on `0.10.2`, and also if we could activate `allow-deprecated-api=false` on c-lightning, in which case the `invoicewithdescriptionhash` doesn't work, but we the library doesn't care because it uses the native API of Core lightning.