### PR TITLE
Eclair updates

### DIFF
--- a/src/BTCPayServer.Lightning.Eclair/EclairClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairClient.cs
@@ -8,10 +8,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using BTCPayServer.Lightning.Eclair.Models;
 using NBitcoin;
-using NBitcoin.Protocol;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Newtonsoft.Json.Serialization;
 
 namespace BTCPayServer.Lightning.Eclair
 {
@@ -21,7 +19,7 @@ namespace BTCPayServer.Lightning.Eclair
         private readonly string _username;
         private readonly string _password;
         private readonly HttpClient _httpClient;
-        private static readonly HttpClient SharedClient = new HttpClient();
+        private static readonly HttpClient SharedClient = new ();
 
         public Network Network { get; }
 
@@ -215,7 +213,7 @@ namespace BTCPayServer.Lightning.Eclair
             CancellationToken cts = default)
         {
             return await SendCommandAsync<GetReceivedInfoRequest, GetReceivedInfoResponse>("getreceivedinfo",
-                new GetReceivedInfoRequest()
+                new GetReceivedInfoRequest
                 {
                     PaymentHash = paymentHash,
                     Invoice = invoice

--- a/src/BTCPayServer.Lightning.Eclair/Models/GetSentInfoResponse.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/GetSentInfoResponse.cs
@@ -13,21 +13,15 @@ namespace BTCPayServer.Lightning.Eclair.Models
         public string PaymentHash { get; set; }
         public string PaymentType { get; set; }
         public string RecipientNodeId { get; set; }
-        public string Preimage { get; set; }
         public long AmountMsat { get; set; }
         [JsonConverter(typeof(EclairDateTimeJsonConverter))]
         public DateTimeOffset CreatedAt { get; set; }
-        [JsonConverter(typeof(EclairDateTimeJsonConverter))]
-        public DateTimeOffset CompletedAt { get; set; }
 
         [JsonConverter(typeof(LightMoneyJsonConverter))]
         public LightMoney RecipientAmount { get; set; }
 
         [JsonConverter(typeof(LightMoneyJsonConverter))]
         public LightMoney Amount { get; set; }
-
-        [JsonConverter(typeof(LightMoneyJsonConverter))]
-        public long FeesPaid { get; set; }
 
         public PaymentStatus Status { get; set; }
     }

--- a/src/BTCPayServer.Lightning.Eclair/Models/GlobalBalanceResponse.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/GlobalBalanceResponse.cs
@@ -31,9 +31,9 @@ namespace BTCPayServer.Lightning.Eclair.Models
         [JsonConverter(typeof(LightMoneyJsonConverter))]
         public LightMoney WaitForFundingConfirmed { get; set; }
         
-        [JsonProperty("waitForFundingLocked")]
+        [JsonProperty("waitForChannelReady")]
         [JsonConverter(typeof(LightMoneyJsonConverter))]
-        public LightMoney WaitForFundingLocked { get; set; }
+        public LightMoney WaitForChannelReady { get; set; }
         
         [JsonProperty("waitForPublishFutureCommitment")]
         [JsonConverter(typeof(LightMoneyJsonConverter))]

--- a/src/BTCPayServer.Lightning.Eclair/Models/PaymentStatus.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/PaymentStatus.cs
@@ -1,7 +1,38 @@
+using System;
+using System.Collections.Generic;
+using BTCPayServer.Lightning.Eclair.JsonConverters;
+using BTCPayServer.Lightning.JsonConverters;
+using Newtonsoft.Json;
+
 namespace BTCPayServer.Lightning.Eclair.Models
 {
     public class PaymentStatus
     {
-        public string type { get; set; }
+        public string Type { get; set; }
+        public string PaymentPreimage { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney FeesPaid { get; set; }
+        
+        [JsonConverter(typeof(EclairDateTimeJsonConverter))]
+        public DateTimeOffset CompletedAt { get; set; }
+        
+        public List<PaymentRoutes> Route { get; set; }
+        public List<PaymentFailures> Failures { get; set; }
+    }
+
+    public class PaymentRoutes
+    {
+        public string NodeId { get; set; }
+        public string NextNodeId { get; set; }
+        public string ShortChannelId { get; set; }
+    }
+
+    public class PaymentFailures
+    {
+        public string FailureType { get; set; }
+        public string FailureMessage { get; set; }
+        public string FailedNode { get; set; }
+        public List<PaymentRoutes> FailedRoute { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.Eclair/Models/SendToNodeRequest.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/SendToNodeRequest.cs
@@ -4,7 +4,6 @@ namespace BTCPayServer.Lightning.Eclair.Models
     {
         public string NodeId { get; set; }
         public long? AmountMsat { get; set; }
-        public string PaymentHash { get; set; }
         public int? MaxAttempts { get; set; }
         public int? MaxFeePct { get; set; }
         public long? MaxFeeFlatSat { get; set; }

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -18,7 +18,6 @@ using NBitcoin.RPC;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
-using Newtonsoft.Json;
 
 namespace BTCPayServer.Lightning.Tests
 {
@@ -68,6 +67,7 @@ namespace BTCPayServer.Lightning.Tests
                 retrievedInvoice = await client.Client.GetInvoice("lol");
                 Assert.Null(retrievedInvoice);
                 
+                await Task.Delay(1000);
                 var invoices = await client.Client.ListInvoices();
                 Assert.Contains(invoices, invoice => invoice.Id == createdInvoice.Id);
                 
@@ -407,17 +407,9 @@ namespace BTCPayServer.Lightning.Tests
                 {
                     case LndClient _:
                     case CLightningClient _:
+                    case EclairLightningClient _:
                         var response = await src.Pay(param);
                         Assert.Equal(PayResult.Ok, response.Result);
-
-                        var invoice = await dest.GetInvoice(Encoders.Hex.EncodeData(paymentHash.ToBytes()));
-                        //var payment = await src.GetPayment(paymentHash.ToString());
-                        break;
-                    
-                    case EclairLightningClient _:
-                        var resp = await src.Pay(param);
-                        // TODO: Fix route finding issue for Eclair
-                        Assert.IsType<PayResult>(resp.Result);
                         break;
 
                     default:
@@ -509,6 +501,8 @@ retry:
                 Assert.Equal(amount, paidInvoice.Amount);
                 Assert.Equal(amount, paidInvoice.AmountReceived);
 
+                await Task.Delay(1000);
+                
                 // check invoices lists: not present in pending, but in general list
                 var onlyPending = new ListInvoicesParams { PendingOnly = true };
                 var invoices = await test.Merchant.ListInvoices(onlyPending);

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -181,7 +181,7 @@ services:
   eclair:
     restart: unless-stopped
     stop_signal: SIGKILL
-    image: acinq/eclair:release-0.7.0
+    image: acinq/eclair:release-0.8.0
     environment:
       JAVA_OPTS: |
         -Xmx256m
@@ -206,6 +206,7 @@ services:
         -Don-chain-fees.feerate-tolerance.ratio-high=100.0
         -Declair.channel.mindepth-blocks=1
         -Declair.ping-disconnect=false
+        -Declair.features.keysend=optional
     ports:
       - "4570:8080" # api port
       - "9735:9735" # server port
@@ -222,7 +223,7 @@ services:
   eclair_dest:
     restart: unless-stopped
     stop_signal: SIGKILL
-    image: acinq/eclair:release-0.7.0
+    image: acinq/eclair:release-0.8.0
     environment:
       JAVA_OPTS: |
         -Xmx256m
@@ -247,6 +248,7 @@ services:
         -Don-chain-fees.feerate-tolerance.ratio-high=100.0
         -Declair.channel.mindepth-blocks=1
         -Declair.ping-disconnect=false
+        -Declair.features.keysend=optional
     ports:
       - "4571:8080" # api port
       - "9736:9736" # server port


### PR DESCRIPTION
Extracted these from #111:

- Incorporate payment timeout pattern from #106
- Improve failure response
- Fix missing payment info (some [`getsentinfo` properties](https://acinq.github.io/eclair/#getsentinfo) weren't correct)
- Upgrade containers to 0.8.0