### PR TITLE
LightMoney: Fix float conversion

### DIFF
--- a/src/BTCPayServer.Lightning.Eclair/JsonConverters/EclairBtcJsonConverter.cs
+++ b/src/BTCPayServer.Lightning.Eclair/JsonConverters/EclairBtcJsonConverter.cs
@@ -1,13 +1,16 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
+using System.Text;
+using NBitcoin;
 using NBitcoin.JsonConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace BTCPayServer.Lightning.JsonConverters
+namespace BTCPayServer.Lightning.Eclair.JsonConverters
 {
-    public class LightMoneyJsonConverter : JsonConverter
+    public class EclairBtcJsonConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {
@@ -23,12 +26,13 @@ namespace BTCPayServer.Lightning.JsonConverters
                 {
                     JsonToken.Null => null,
                     JsonToken.Integer => _longType.IsAssignableFrom(reader.ValueType)
-                        ? new LightMoney((long)reader.Value)
-                        : new LightMoney(long.MaxValue),
-                    JsonToken.Float => new LightMoney(Convert.ToInt64(reader.Value)),
+                        ? new LightMoney((long)reader.Value, LightMoneyUnit.BTC)
+                        : new LightMoney(long.MaxValue, LightMoneyUnit.BTC),
+                    // Eclair denominates global balance amounts in BTC, see https://acinq.github.io/eclair/#globalbalance
+                    JsonToken.Float => new LightMoney(Convert.ToDecimal(reader.Value), LightMoneyUnit.BTC),
                     JsonToken.String =>
                         // some of the c-lightning values have a trailing "msat" that we need to remove before parsing
-                        new LightMoney(long.Parse(((string)reader.Value).Replace("msat", ""), CultureInfo.InvariantCulture)),
+                        new LightMoney(long.Parse(((string)reader.Value).Replace("msat", ""), CultureInfo.InvariantCulture), LightMoneyUnit.BTC),
                     // Fix for Eclair having empty objects for zero amount cases, see https://acinq.github.io/eclair/#globalbalance
                     JsonToken.StartObject => JObject.Load(reader) != null ? LightMoney.Zero : null,
                     _ => null
@@ -36,13 +40,14 @@ namespace BTCPayServer.Lightning.JsonConverters
             }
             catch (InvalidCastException)
             {
-                throw new JsonObjectException("Money amount should be in millisatoshi", reader);
+                throw new JsonObjectException("Money amount should be in BTC", reader);
             }
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            writer.WriteValue(((LightMoney)value).MilliSatoshi);
+            writer.WriteValue(((LightMoney)value).ToUnit(LightMoneyUnit.Bit));
         }
     }
 }
+

--- a/src/BTCPayServer.Lightning.Eclair/Models/GlobalBalanceResponse.cs
+++ b/src/BTCPayServer.Lightning.Eclair/Models/GlobalBalanceResponse.cs
@@ -1,3 +1,4 @@
+using BTCPayServer.Lightning.Eclair.JsonConverters;
 using BTCPayServer.Lightning.JsonConverters;
 using NBitcoin;
 using Newtonsoft.Json;
@@ -28,19 +29,19 @@ namespace BTCPayServer.Lightning.Eclair.Models
     public class GlobalOffchainBalance
     {
         [JsonProperty("waitForFundingConfirmed")]
-        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        [JsonConverter(typeof(EclairBtcJsonConverter))]
         public LightMoney WaitForFundingConfirmed { get; set; }
         
         [JsonProperty("waitForChannelReady")]
-        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        [JsonConverter(typeof(EclairBtcJsonConverter))]
         public LightMoney WaitForChannelReady { get; set; }
         
         [JsonProperty("waitForPublishFutureCommitment")]
-        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        [JsonConverter(typeof(EclairBtcJsonConverter))]
         public LightMoney WaitForPublishFutureCommitment { get; set; }
         
         [JsonProperty("negotiating")]
-        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        [JsonConverter(typeof(EclairBtcJsonConverter))]
         public LightMoney Negotiating { get; set; }
         
         [JsonProperty("normal")]
@@ -72,7 +73,7 @@ namespace BTCPayServer.Lightning.Eclair.Models
     public class EclairChannelBalance
     {
         [JsonProperty("toLocal")]
-        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        [JsonConverter(typeof(EclairBtcJsonConverter))]
         public LightMoney ToLocal { get; set; }
     }
 }

--- a/tests/JsonTests.cs
+++ b/tests/JsonTests.cs
@@ -1,3 +1,4 @@
+using BTCPayServer.Lightning.Eclair.JsonConverters;
 using BTCPayServer.Lightning.JsonConverters;
 using Newtonsoft.Json;
 using Xunit;
@@ -14,6 +15,11 @@ namespace BTCPayServer.Lightning.Tests
             var json = JsonConvert.SerializeObject(lm, converter);
 
             Assert.Equal(lm.MilliSatoshi, JsonConvert.DeserializeObject<LightMoney>(json, converter).MilliSatoshi);
+            Assert.Equal(3187032000, JsonConvert.DeserializeObject<LightMoney>("3187032000.0", converter).MilliSatoshi);
+            Assert.Equal("123", JsonConvert.SerializeObject(123, converter));
+
+            var eclairConverter = new EclairBtcJsonConverter();
+            Assert.Equal(89997146000, JsonConvert.DeserializeObject<LightMoney>("0.89997146", eclairConverter).MilliSatoshi);
         }
     }
 }


### PR DESCRIPTION
Eclair denominates global balance amounts in BTC and Charge seems to export large amounts as floats.

The solution is to separate the two clearly and fix the float conversion in the `LightMoneyJsonConverter`.

Fixes btcpayserver/btcpayserver#4383.