### PR TITLE
LNbank fixes

### DIFF
--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -22,6 +22,6 @@
 		<ProjectReference Include="..\BTCPayServer.Lightning.LND\BTCPayServer.Lightning.LND.csproj" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.10"></PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0"></PackageReference>
   </ItemGroup>
 </Project>

--- a/src/BTCPayServer.Lightning.Common/CreateInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/CreateInvoiceParams.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Text;
-using BTCPayServer.Lightning.JsonConverters;
 using NBitcoin;
 using NBitcoin.Crypto;
-using Newtonsoft.Json;
 
 namespace BTCPayServer.Lightning
 {
@@ -52,8 +50,6 @@ namespace BTCPayServer.Lightning
             }
         }
         public bool DescriptionHashOnly { get; set; }
-        
-        [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         public TimeSpan Expiry { get; set; }
         public bool PrivateRouteHints { get; set; }
     }

--- a/src/BTCPayServer.Lightning.Common/CreateInvoiceParams.cs
+++ b/src/BTCPayServer.Lightning.Common/CreateInvoiceParams.cs
@@ -1,10 +1,9 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
+using BTCPayServer.Lightning.JsonConverters;
 using NBitcoin;
 using NBitcoin.Crypto;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Lightning
 {
@@ -21,6 +20,7 @@ namespace BTCPayServer.Lightning
             Description = description;
             Expiry = expiry;
         }
+        
         [Obsolete("Set the Description and turn DescriptionHashOnly to true instead")]
         public CreateInvoiceParams(LightMoney amount, uint256 descriptionHash, TimeSpan expiry)
         {
@@ -52,6 +52,8 @@ namespace BTCPayServer.Lightning
             }
         }
         public bool DescriptionHashOnly { get; set; }
+        
+        [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         public TimeSpan Expiry { get; set; }
         public bool PrivateRouteHints { get; set; }
     }

--- a/src/BTCPayServer.Lightning.Common/JsonConverters/TimeSpanJsonConverter.cs
+++ b/src/BTCPayServer.Lightning.Common/JsonConverters/TimeSpanJsonConverter.cs
@@ -1,0 +1,78 @@
+using System;
+using NBitcoin.JsonConverters;
+using Newtonsoft.Json;
+
+namespace BTCPayServer.Lightning.JsonConverters;
+
+public abstract class TimeSpanJsonConverter : JsonConverter
+{
+    public class Seconds : TimeSpanJsonConverter
+    {
+        protected override long ToLong(TimeSpan value)
+        {
+            return (long)value.TotalSeconds;
+        }
+
+        protected override TimeSpan ToTimespan(long value)
+        {
+            return TimeSpan.FromSeconds(value);
+        }
+    }
+    public class Minutes : TimeSpanJsonConverter
+    {
+        protected override long ToLong(TimeSpan value)
+        {
+            return (long)value.TotalMinutes;
+        }
+        protected override TimeSpan ToTimespan(long value)
+        {
+            return TimeSpan.FromMinutes(value);
+        }
+    }
+    public class Days : TimeSpanJsonConverter
+    {
+        protected override long ToLong(TimeSpan value)
+        {
+            return (long)value.TotalDays;
+        }
+        protected override TimeSpan ToTimespan(long value)
+        {
+            return TimeSpan.FromDays(value);
+        }
+    }
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(TimeSpan) || objectType == typeof(TimeSpan?);
+    }
+
+    protected abstract TimeSpan ToTimespan(long value);
+    protected abstract long ToLong(TimeSpan value);
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        try
+        {
+            var nullable = objectType == typeof(TimeSpan?);
+            if (reader.TokenType == JsonToken.Null)
+            {
+                if (nullable)
+                    return null;
+                return TimeSpan.Zero;
+            }
+            if (reader.TokenType != JsonToken.Integer)
+                throw new JsonObjectException("Invalid timespan, expected integer", reader);
+            return ToTimespan((long)reader.Value);
+        }
+        catch
+        {
+            throw new JsonObjectException("Invalid timespan", reader);
+        }
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        if (value is TimeSpan s)
+        {
+            writer.WriteValue(ToLong(s));
+        }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -18,7 +19,7 @@ namespace BTCPayServer.Lightning.LNbank
         private readonly Uri _baseUri;
         private readonly HttpClient _httpClient;
         private readonly Network _network;
-        private static readonly HttpClient _sharedClient = new HttpClient();
+        private static readonly HttpClient _sharedClient = new ();
 
         public LNbankClient(Uri baseUri, string apiToken, Network network, HttpClient httpClient)
         {
@@ -172,7 +173,7 @@ namespace BTCPayServer.Lightning.LNbank
 
             if (!res.IsSuccessStatusCode)
             {
-                if (res.StatusCode.Equals(422))
+                if (res.StatusCode.Equals(422) || res.StatusCode.ToString().Equals("UnprocessableEntity"))
                 {
                     var validationErrors = JsonConvert.DeserializeObject<GreenfieldValidationErrorData[]>(str);
                     var message = string.Join(", ", validationErrors.Select(ve => $"{ve.Path}: {ve.Message}"));

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -173,7 +172,7 @@ namespace BTCPayServer.Lightning.LNbank
 
             if (!res.IsSuccessStatusCode)
             {
-                if (res.StatusCode.Equals(422) || res.StatusCode.ToString().Equals("UnprocessableEntity"))
+                if ((int)res.StatusCode == 422)
                 {
                     var validationErrors = JsonConvert.DeserializeObject<GreenfieldValidationErrorData[]>(str);
                     var message = string.Join(", ", validationErrors.Select(ve => $"{ve.Path}: {ve.Message}"));

--- a/src/BTCPayServer.Lightning.LNbank/Models/CreateInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/CreateInvoiceRequest.cs
@@ -16,6 +16,7 @@ namespace BTCPayServer.Lightning.LNbank.Models
         [JsonConverter(typeof(LightMoneyJsonConverter))]
         public LightMoney Amount { get; set; }
 
+        [JsonConverter(typeof(TimeSpanJsonConverter.Seconds))]
         public TimeSpan Expiry { get; set; }
         public bool PrivateRouteHints { get; set; }
     }


### PR DESCRIPTION
Fixes btcpayserver/btcpayserver#4458 by adding TimeSpan conversion for the request classes.

The Logging.Abstractions upgrade fixes version mismatches with BTCPay Server ­— I came across those when I integrated the Lightning lib locally inside the main project to debug this.