### PR TITLE
CLN + LNbank: Minor updates

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -526,7 +526,7 @@ namespace BTCPayServer.Lightning.CLightning
             {
                 foreach (var channel in peer.Channels)
                 {
-                    channels.Add(new LightningChannel()
+                    channels.Add(new LightningChannel
                     {
                         RemoteNode = new PubKey(peer.Id),
                         IsPublic = !channel.Private,
@@ -545,7 +545,7 @@ namespace BTCPayServer.Lightning.CLightning
             {
                 Id = invoice.Label,
                 PaymentHash = invoice.PaymentHash.ToString(),
-                Preimage = invoice.PaymentPreimage?.ToString() ?? invoice.PaymentSecret?.ToString(),
+                Preimage = invoice.PaymentPreimage?.ToString(),
                 Amount = invoice.MilliSatoshi,
                 AmountReceived = invoice.MilliSatoshiReceived,
                 BOLT11 = invoice.BOLT11,

--- a/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankClient.cs
@@ -38,9 +38,9 @@ namespace BTCPayServer.Lightning.LNbank
             return await Get<LightningNodeBalance>("balance", cancellation);
         }
 
-        public async Task<InvoiceData> GetInvoice(string invoiceId, CancellationToken cancellation)
+        public async Task<InvoiceData> GetInvoice(string paymentHashOrInvoiceId, CancellationToken cancellation)
         {
-            return await Get<InvoiceData>($"invoice/{invoiceId}", cancellation);
+            return await Get<InvoiceData>($"invoice/{paymentHashOrInvoiceId}", cancellation);
         }
 
         public async Task<InvoiceData[]> ListInvoices(ListInvoicesParams param, CancellationToken cancellation)

--- a/src/BTCPayServer.Lightning.LNbank/LNbankHubClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankHubClient.cs
@@ -41,7 +41,8 @@ namespace BTCPayServer.Lightning.LNbank
 
                 _connection.On<TransactionUpdateEvent>("transaction-update", async data =>
                 {
-                    invoice = await _lightningClient.GetInvoice(data.InvoiceId, cancellation);
+                    var id = data.PaymentHash ?? data.InvoiceId;
+                    invoice = await _lightningClient.GetInvoice(id, cancellation);
 
                     if (invoice != null)
                         tcs.SetResult(invoice);

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -57,11 +57,11 @@ namespace BTCPayServer.Lightning.LNbank
             }
         }
 
-        public async Task<LightningInvoice> GetInvoice(string invoiceId, CancellationToken cancellation = default)
+        public async Task<LightningInvoice> GetInvoice(string paymentHash, CancellationToken cancellation = default)
         {
             try
             {
-                var invoice = await _client.GetInvoice(invoiceId, cancellation);
+                var invoice = await _client.GetInvoice(paymentHash, cancellation);
                 return ToLightningInvoice(invoice);
             }
             catch (LNbankClient.LNbankApiException)

--- a/src/BTCPayServer.Lightning.LNbank/Models/TransactionUpdateEvent.cs
+++ b/src/BTCPayServer.Lightning.LNbank/Models/TransactionUpdateEvent.cs
@@ -4,6 +4,7 @@ namespace BTCPayServer.Lightning.LNbank.Models
     {
         public string TransactionId { get; set; }
         public string InvoiceId { get; set; }
+        public string PaymentHash { get; set; }
         public string Status { get; set; }
         public string Event { get; set; }
         public bool IsPaid { get; set; }


### PR DESCRIPTION
Corrects a mistake in CLN I must have made where the Preimage property gets populated with the PaymentSecret as a fallback.

Makes the LNbank listener prefer the payment hash to lookup an invoice. Falls back to invoice id and makes it clearer, that both might be used.