### PR TITLE
LNDhub: Make InvoiceData compatible with LNDhub.go

### DIFF
--- a/src/BTCPayServer.Lightning.LNDhub/JsonConverters/LndHubBufferJsonConverter.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/JsonConverters/LndHubBufferJsonConverter.cs
@@ -14,12 +14,18 @@ namespace BTCPayServer.Lightning.LNDhub.JsonConverters
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
-            if (reader.TokenType != JsonToken.StartObject) return null;
-        
-            var obj = JObject.Load(reader);
-            return obj["type"]?.Value<string>() == "Buffer" && obj["data"] != null
-                ? new uint256(BitString(obj["data"].ToObject<byte[]>()))
-                : null;
+            switch (reader.TokenType)
+            {
+                case JsonToken.String:
+                    return uint256.Parse((string)reader.Value);
+                case JsonToken.StartObject:
+                    var obj = JObject.Load(reader);
+                    return obj["type"]?.Value<string>() == "Buffer" && obj["data"] != null
+                        ? new uint256(BitString(obj["data"].ToObject<byte[]>()))
+                        : null;
+                default:
+                    return null;
+            };
         }
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubLightningClient.cs
@@ -128,7 +128,7 @@ namespace BTCPayServer.Lightning.LndHub
             var invoice = await _client.CreateInvoice(req, cancellation);
 
             // the response to addinvoice is incomplete, fetch the invoice to return that data
-            return await GetInvoice(invoice.Id.ToString(), cancellation);
+            return await GetInvoice(invoice.Id, cancellation);
         }
 
         public async Task<PayResponse> Pay(string bolt11, CancellationToken cancellation = default)


### PR DESCRIPTION
Handles the case `r_hash` as a string. LNDhub sends it as a Buffer object, LNDhub.go as string. Closes btcpayserver/btcpayserver#4658.