### PR TITLE
Bumping LND to 0.16.0-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.15.4-beta-1
+    image: btcpayserver/lnd:v0.16.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -147,7 +147,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.15.4-beta-1
+    image: btcpayserver/lnd:v0.16.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.16.0-beta/images/sha256-ddc2dea59306e45957ea9a4bdd8b0d39662bf1996f89b6bc193922a33b07951d?context=repo