### PR TITLE
Bumping LND to 0.16.1-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.16.0-beta
+    image: btcpayserver/lnd:v0.16.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -147,7 +147,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.16.0-beta
+    image: btcpayserver/lnd:v0.16.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.16.1-beta/images/sha256-8cd728f1103ae9994dbbdd0f10d12807a946706d91f885af1b2ba13737eb722e?context=explore

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.16.1-beta