### PR TITLE
Bumping LND to 0.16.2-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.16.1-beta
+    image: btcpayserver/lnd:v0.16.2-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -147,7 +147,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.16.1-beta
+    image: btcpayserver/lnd:v0.16.2-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.16.2-beta/images/sha256-ce3bf85e3380cd74d8e1ecdab6c0d45ad8364a4c3689be0de6cc23fca20d8c81?context=explore

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.16.2-beta