### PR TITLE
Fix LNBank listening loop

### DIFF
--- a/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
+++ b/src/BTCPayServer.Lightning.All/BTCPayServer.Lightning.All.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
 		<RootNamespace>BTCPayServer.Lightning</RootNamespace>
-		<Version>1.4.24</Version>
+		<Version>1.4.25</Version>
 		<LangVersion>10</LangVersion>
 		<PackageId>BTCPayServer.Lightning.All</PackageId>
 		<Description>Client library for lightning network implementations to build Lightning Network Apps in C#.</Description>

--- a/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
+++ b/src/BTCPayServer.Lightning.LNbank/BTCPayServer.Lightning.LNbank.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <Import Project="../Build/Common.csproj"></Import>
     <PropertyGroup>
         <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
-        <Version>1.3.24</Version>
+        <Version>1.3.25</Version>
         <PackageId>BTCPayServer.Lightning.LNBank</PackageId>
         <Description>Client library for LNBank to build Lightning Network Apps in C#.</Description>
         <PackageProjectUrl>https://github.com/btcpayserver/BTCPayServer.Lightning</PackageProjectUrl>

--- a/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
+++ b/src/BTCPayServer.Lightning.LNbank/LNbankLightningClient.cs
@@ -236,7 +236,7 @@ namespace BTCPayServer.Lightning.LNbank
 
         public async Task<ILightningInvoiceListener> Listen(CancellationToken cancellation = default)
         {
-            var listener = new LNbankHubClient(_baseUri, _apiToken, this, cancellation);
+            var listener = new LNbankHubClient(_baseUri, _apiToken, this);
 
             await listener.Start(cancellation);
 


### PR DESCRIPTION
Fixes dennisreimann/btcpayserver-plugin-lnbank#33

Every times a new invoice come, a new handler would listen to the hub. Eventually, the client would stop seeing new lightning transactions.

Ping @dennisreimann 