### PR TITLE
Eclair: Fix build warning

### DIFF
--- a/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
@@ -447,7 +447,7 @@ namespace BTCPayServer.Lightning.Eclair
             return channels.Select(response =>
             {
                 var outpointStr = response.Data?.Commitments?.CommitInput?.OutPoint?.Replace(":", "-");
-                OutPoint? outPoint = null;
+                OutPoint outPoint = null;
                 if (outpointStr != null)
                     OutPoint.TryParse(outpointStr, out outPoint);
 


### PR DESCRIPTION
Minor fix for this build warning in the Eclair module:

```
/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs(450,25): warning CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context. [/src/BTCPayServer.Lightning.Eclair/BTCPayServer.Lightning.Eclair.csproj]
```