### PR TITLE
LND: Fix custom record aggregation

### DIFF
--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -553,7 +553,10 @@ namespace BTCPayServer.Lightning.LND
             if (resp.Htlcs != null && resp.Htlcs.Any())
             {
                 invoice.CustomRecords = resp.Htlcs
+                    .Where(htlc => htlc.State.ToUpperInvariant() == "SETTLED")
                     .SelectMany(htlc => htlc.CustomRecords)
+                    .GroupBy(htlc => htlc.Key)
+                    .Select(x => x.First())
                     .ToDictionary(x => x.Key, y => y.Value);
             }
             


### PR DESCRIPTION
At a later point we can expose the HTLCs completely, for now this is a simple fix for the aggregation of the custom records with multiple settled HTLCs.