### PR TITLE
Bumping LND to 0.16.4-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.16.3-beta
+    image: btcpayserver/lnd:v0.16.4-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -147,7 +147,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.16.3-beta
+    image: btcpayserver/lnd:v0.16.4-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.16.4-beta/images/sha256-83667cf6efa57b903244847691dd99f01a64e8f6ba18f4b7506754886df7cecc?context=explore

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.16.4-beta