### PR TITLE
Fix order of parsing logic

### DIFF
--- a/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
+++ b/src/BTCPayServer.Lightning.All/LightningConnectionString.cs
@@ -52,22 +52,14 @@ namespace BTCPayServer.Lightning
         {
             if (str == null)
                 throw new ArgumentNullException(nameof(str));
-
-            if (supportLegacy)
-            {
-                var parsed = TryParseLegacy(str, out connectionString, out error);
-                if (!parsed)
-                {
-                    parsed = TryParseNewFormat(str, out connectionString, out error);
-                }
-                return parsed;
-            }
-
             if (str.StartsWith("lndhub://"))
             {
                 return TryParseLNDhub(str, out connectionString, out error);
             }
-            
+            if (supportLegacy && TryParseLegacy(str, out connectionString, out error))
+            {
+                return true;
+            }
             return TryParseNewFormat(str, out connectionString, out error);
         }
 


### PR DESCRIPTION
Before, if supportLegacy was true, it would not attempt to parse lndhub style connections