### PR TITLE
Explicitly set maxfee in CLN

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -337,18 +337,14 @@ namespace BTCPayServer.Lightning.CLightning
                 // cln doesn't like using an explicit amount if it's the bolt's minimum amount for some reason
                 var explicitAmount = pr?.MinimumAmount == payParams?.Amount ? null : payParams?.Amount;
                 var feePercent = payParams?.MaxFeePercent;
-                if (feePercent is null && payParams?.MaxFeeFlat is Money m && pr is not null)
-                {
-                    var amountSat = (explicitAmount ?? pr.MinimumAmount).ToUnit(LightMoneyUnit.Satoshi);
-                    feePercent = (double)(m.Satoshi / amountSat) * 100;
-                }
+                var maxFeeFlat = payParams?.MaxFeeFlat.Satoshi*1000;
 
                 var command = isKeysend ? "keysend" : "pay";
                 var opts = isKeysend
                     // keysend: destination msatoshi [label] [maxfeepercent] [retry_for] [maxdelay] [exemptfee] [extratlvs]
                     ? new object[] { payParams.Destination.ToHex(), explicitAmount.MilliSatoshi, null, feePercent }
                     // pay: bolt11 [msatoshi] [label] [riskfactor] [maxfeepercent] [retry_for] [maxdelay] [exemptfee] [localinvreqid] [exclude] [maxfee] [description]
-                    : new object[] { bolt11, explicitAmount?.MilliSatoshi, null, null, feePercent };
+                    : new object[] { bolt11, explicitAmount?.MilliSatoshi, null, null, feePercent, null, null, null, null, null, maxFeeFlat };
                 var response = await SendCommandAsync<CLightningPayResponse>(command, opts, false, cancellation: cts.Token);
 
                 return new PayResponse(PayResult.Ok, new PayDetails

--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -336,8 +336,8 @@ namespace BTCPayServer.Lightning.CLightning
                 var pr = bolt11 is null ? null : BOLT11PaymentRequest.Parse(bolt11, Network);
                 // cln doesn't like using an explicit amount if it's the bolt's minimum amount for some reason
                 var explicitAmount = pr?.MinimumAmount == payParams?.Amount ? null : payParams?.Amount;
-                var feePercent = payParams?.MaxFeePercent;
-                var maxFeeFlat = payParams?.MaxFeeFlat.Satoshi*1000;
+                var maxFeeFlat = payParams?.MaxFeeFlat.Satoshi*1_000;
+                var feePercent = maxFeeFlat is null ? payParams?.MaxFeePercent : null;
 
                 var command = isKeysend ? "keysend" : "pay";
                 var opts = isKeysend

--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -336,7 +336,7 @@ namespace BTCPayServer.Lightning.CLightning
                 var pr = bolt11 is null ? null : BOLT11PaymentRequest.Parse(bolt11, Network);
                 // cln doesn't like using an explicit amount if it's the bolt's minimum amount for some reason
                 var explicitAmount = pr?.MinimumAmount == payParams?.Amount ? null : payParams?.Amount;
-                var maxFeeFlat = payParams?.MaxFeeFlat.Satoshi*1_000;
+                long? maxFeeFlat = payParams?.MaxFeeFlat is null ? null : new LightMoney(payParams?.MaxFeeFlat).MilliSatoshi;
                 var feePercent = maxFeeFlat is null ? payParams?.MaxFeePercent : null;
 
                 var command = isKeysend ? "keysend" : "pay";


### PR DESCRIPTION
From the CLN docs: 

> maxfee overrides both maxfeepercent and exemptfee defaults (and if you specify maxfee you cannot specify either of those), and creates an absolute limit on what fee we will pay. This allows you to implement your own heuristics rather than the primitive ones used here.

https://docs.corelightning.org/reference/lightning-pay