### PR TITLE
Bumping LND to 0.17.1-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.0-beta
+    image: btcpayserver/lnd:v0.17.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -147,7 +147,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.0-beta
+    image: btcpayserver/lnd:v0.17.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.17.1-beta/images/sha256-b5c106136bd33a422463c736a1db8bd3541f95ac6f277dae86ab2a01b0c3445a?context=explore

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.17.1-beta