### PR TITLE
LNDhub fixes

### DIFF
--- a/src/BTCPayServer.Lightning.LNDhub/JsonConverters/LndHubTimeSpanJsonConverter.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/JsonConverters/LndHubTimeSpanJsonConverter.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Reflection;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Lightning.LNDhub.JsonConverters
 {

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
@@ -26,7 +26,7 @@ namespace BTCPayServer.Lightning.LndHub
         private readonly string _password;
         private readonly JsonSerializer _serializer;
         private readonly Network _network;
-        private static readonly HttpClient _sharedClient = new HttpClient();
+        private static readonly HttpClient _sharedClient = new ();
 
         private string AccessToken { get; set; }
         private string RefreshToken { get; set; }
@@ -131,7 +131,7 @@ namespace BTCPayServer.Lightning.LndHub
 
             var req = new HttpRequestMessage
             {
-                RequestUri = new Uri($"{_baseUri}{path}"),
+                RequestUri = new Uri($"{WithTrailingSlash(_baseUri.ToString())}{path}"),
                 Method = method,
                 Content = content
             };
@@ -197,7 +197,7 @@ namespace BTCPayServer.Lightning.LndHub
         private async Task<bool> Authorize(CancellationToken cancellation = default)
         {
             var payload = new AuthRequest { Login = _login, Password = _password };
-            var response = await Post<AuthRequest, AuthResponse>("auth", payload, cancellation);
+            var response = await Post<AuthRequest, AuthResponse>("auth?type=auth", payload, cancellation);
 
             AccessToken = response.AccessToken;
             RefreshToken = response.RefreshToken;
@@ -206,7 +206,7 @@ namespace BTCPayServer.Lightning.LndHub
         }
 
         private static string WithTrailingSlash(string str) =>
-            str.EndsWith("/", StringComparison.InvariantCulture) ? str :str + "/";
+            str.EndsWith("/", StringComparison.InvariantCulture) ? str : str + "/";
 
         private class EmptyRequestModel
         {

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
@@ -139,7 +139,7 @@ namespace BTCPayServer.Lightning.LndHub
             req.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             req.Headers.Add("User-Agent", "BTCPayServer.Lightning.LndHubClient");
 
-            if (path != "auth" && path != "create")
+            if (!path.StartsWith("auth") && path != "create")
             {
                 if (string.IsNullOrEmpty(AccessToken))
                 {

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubConnectionStringHandler.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubConnectionStringHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Net.Http;
 using BTCPayServer.Lightning.LndHub;
@@ -25,10 +25,11 @@ public class LndHubConnectionStringHandler : ILightningConnectionStringHandler
         }
             
         // transform into connection string format
-        transformedConnectionString = $"type=lndhub;server={uri.AbsoluteUri}";
+        transformedConnectionString = $"type=lndhub;server={uri.AbsoluteUri}" + (uri.Scheme == "http" ? ";allowinsecure=true" : "");
         error = null;
         return true; 
     }
+
     public ILightningClient Create(string connectionString, Network network, out string error)
     {
         if(connectionString.StartsWith("lndhub://", StringComparison.OrdinalIgnoreCase))
@@ -48,8 +49,7 @@ public class LndHubConnectionStringHandler : ILightningConnectionStringHandler
             return null;
         }
 
-        if (!Uri.TryCreate(server, UriKind.Absolute, out var uri)
-            || uri.Scheme != "http" && uri.Scheme != "https")
+        if (!Uri.TryCreate(server, UriKind.Absolute, out var uri) || uri.Scheme != "http" && uri.Scheme != "https")
         {
             error = "The key 'server' should be an URI starting by http:// or https://";
             return null;

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubConnectionStringHandler.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubConnectionStringHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net.Http;
 using BTCPayServer.Lightning.LndHub;
@@ -54,7 +54,6 @@ public class LndHubConnectionStringHandler : ILightningConnectionStringHandler
             error = "The key 'server' should be an URI starting by http:// or https://";
             return null;
         }
-
 
         bool allowInsecure = false;
         if (kv.TryGetValue("allowinsecure", out var allowinsecureStr))

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
@@ -6,9 +6,6 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
-using BTCPayServer.Lightning.LNDhub.Models;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 
 namespace BTCPayServer.Lightning.LndHub
 {

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubUtil.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubUtil.cs
@@ -1,6 +1,5 @@
 using System;
 using BTCPayServer.Lightning.LNDhub.Models;
-using NBitcoin;
 
 namespace BTCPayServer.Lightning.LndHub
 {

--- a/src/BTCPayServer.Lightning.LNDhub/Models/PaymentResponse.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/Models/PaymentResponse.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using BTCPayServer.Lightning.JsonConverters;
 using BTCPayServer.Lightning.LNDhub.JsonConverters;

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -1074,17 +1074,14 @@ retry:
         [Fact]
         public void CanParseLightningURL()
         {
-            
             var network = Tester.Network;
             ILightningClientFactory factory = new LightningClientFactory(network);
-            
+
             ParseCreateAndCheckConsistency(factory, "/test/a", "type=clightning;server=unix://test/a");
             ParseCreateAndCheckConsistency(factory, "unix://test/a", "type=clightning;server=unix://test/a");
             ParseCreateAndCheckConsistency(factory, "tcp://test/a", "type=clightning;server=tcp://test/a");
             ParseCreateAndCheckConsistency(factory, "http://aaa:bbb@test/a", "type=charge;server=http://aaa:bbb@test/a;allowinsecure=true");
             ParseCreateAndCheckConsistency(factory, "http://api-token:bbb@test/a", "type=charge;server=http://test/a;api-token=bbb;allowinsecure=true");
-            
-            
 
             Assert.False(factory.TryCreate("lol://aaa:bbb@test/a", out var conn, out _));
             Assert.False(factory.TryCreate("https://test/a",out conn, out _));
@@ -1154,6 +1151,14 @@ retry:
             Assert.False(factory.TryCreate("type=lndhub;server=http://mylndhub:password@lndhub.io/", out  conn, out _));
             Assert.True(factory.TryCreate("type=lndhub;server=http://mylndhub:password@lndhub.io/;allowinsecure=true", out  conn, out _));
             Assert.True(factory.TryCreate("type=lndhub;server=http://mylndhub:password@lndhubviator.onion/", out  conn, out _));
+            
+            // lndhub scheme - https
+            Assert.True(factory.TryCreate("lndhub://mylndhub:password@https://lndhub.io", out conn, out _));
+            Assert.Equal("type=lndhub;server=https://mylndhub:password@lndhub.io/", conn.ToString());
+            
+            // lndhub scheme - http
+            Assert.True(factory.TryCreate("lndhub://mylndhub:password@http://lndhub.io", out conn, out _));
+            Assert.Equal("type=lndhub;server=http://mylndhub:password@lndhub.io/;allowinsecure=true", conn.ToString());
         }
 
         private static async Task<RPCClient> GetRPCClient()


### PR DESCRIPTION
- Ensures trailing slash for base URI
- Handles `allowinsecure` for `lndhub://` scheme URLs
- Removes unused imports

Context: dennisreimann/btcpayserver-plugin-lnbank#51