### PR TITLE
Bumping LND to 0.17.2-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.1-beta
+    image: btcpayserver/lnd:v0.17.2-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -147,7 +147,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.1-beta
+    image: btcpayserver/lnd:v0.17.2-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.17.2-beta/images/sha256-936767369b703a67daf6db6a008a3b53c15f407d29a7ad2327a0de28f5951b30?context=explore

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.17.2-beta