### PR TITLE
Optimize LNDHub

### DIFF
--- a/src/BTCPayServer.Lightning.LNDhub/AsyncDuplicateLock.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/AsyncDuplicateLock.cs
@@ -21,11 +21,11 @@ public sealed class AsyncDuplicateLock
         public T Value { get; private set; }
     }
 
-    private readonly Dictionary<object, RefCounted<SemaphoreSlim>> _semaphoreSlims = new();
+    private readonly Dictionary<object, RefCounted<SemaphoreSlim>?> _semaphoreSlims = new();
 
     private SemaphoreSlim GetOrCreate(object key)
     {
-        RefCounted<SemaphoreSlim> item;
+        RefCounted<SemaphoreSlim>? item;
         lock (_semaphoreSlims)
         {
             if (_semaphoreSlims.TryGetValue(key, out item))
@@ -56,9 +56,9 @@ public sealed class AsyncDuplicateLock
     }
     private sealed class Releaser : IDisposable
     {
-        private readonly Dictionary<object, RefCounted<SemaphoreSlim>> _semaphoreSlims;
+        private readonly Dictionary<object, RefCounted<SemaphoreSlim>?> _semaphoreSlims;
 
-        public Releaser(Dictionary<object, RefCounted<SemaphoreSlim>> semaphoreSlims, object key)
+        public Releaser(Dictionary<object, RefCounted<SemaphoreSlim>?> semaphoreSlims, object key)
         {
             _semaphoreSlims = semaphoreSlims;
             Key = key;
@@ -68,7 +68,7 @@ public sealed class AsyncDuplicateLock
 
         public void Dispose()
         {
-            RefCounted<SemaphoreSlim> item;
+            RefCounted<SemaphoreSlim>? item;
             lock (_semaphoreSlims)
             {
                 item = _semaphoreSlims[Key];

--- a/src/BTCPayServer.Lightning.LNDhub/AsyncDuplicateLock.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/AsyncDuplicateLock.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#nullable enable
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,7 +63,8 @@ public sealed class AsyncDuplicateLock
             _semaphoreSlims = semaphoreSlims;
             Key = key;
         }
-        public object Key { get; set; }
+
+        private object Key { get; set; }
 
         public void Dispose()
         {

--- a/src/BTCPayServer.Lightning.LNDhub/AsyncDuplicateLock.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/AsyncDuplicateLock.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BTCPayServer.Lightning.LndHub;
+
+///from https://stackoverflow.com/a/31194647/275504
+public sealed class AsyncDuplicateLock
+{
+    private sealed class RefCounted<T>
+    {
+        public RefCounted(T value)
+        {
+            RefCount = 1;
+            Value = value;
+        }
+
+        public int RefCount { get; set; }
+        public T Value { get; private set; }
+    }
+
+    private readonly Dictionary<object, RefCounted<SemaphoreSlim>> _semaphoreSlims = new();
+
+    private SemaphoreSlim GetOrCreate(object key)
+    {
+        RefCounted<SemaphoreSlim> item;
+        lock (_semaphoreSlims)
+        {
+            if (_semaphoreSlims.TryGetValue(key, out item))
+            {
+                ++item.RefCount;
+            }
+            else
+            {
+                item = new RefCounted<SemaphoreSlim>(new SemaphoreSlim(1, 1));
+                _semaphoreSlims[key] = item;
+            }
+        }
+        return item.Value;
+    }
+    public async Task<IDisposable> LockAsync(object key, CancellationToken cancellationToken = default)
+    {
+        await GetOrCreate(key).WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(_semaphoreSlims, key);
+    }
+    
+    public async Task<IDisposable?> LockOrBustAsync(object key, CancellationToken cancellationToken = default)
+    {
+        var semaphore = GetOrCreate(key);
+        if (semaphore.CurrentCount == 0)
+            return null;
+        await GetOrCreate(key).WaitAsync(cancellationToken).ConfigureAwait(false);
+        return new Releaser(_semaphoreSlims, key);
+    }
+    private sealed class Releaser : IDisposable
+    {
+        private readonly Dictionary<object, RefCounted<SemaphoreSlim>> _semaphoreSlims;
+
+        public Releaser(Dictionary<object, RefCounted<SemaphoreSlim>> semaphoreSlims, object key)
+        {
+            _semaphoreSlims = semaphoreSlims;
+            Key = key;
+        }
+        public object Key { get; set; }
+
+        public void Dispose()
+        {
+            RefCounted<SemaphoreSlim> item;
+            lock (_semaphoreSlims)
+            {
+                item = _semaphoreSlims[Key];
+                --item.RefCount;
+                if (item.RefCount == 0)
+                    _semaphoreSlims.Remove(Key);
+            }
+            item.Value.Release();
+        }
+    }
+}

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
@@ -222,13 +222,12 @@ namespace BTCPayServer.Lightning.LndHub
                     response.Expiry = DateTimeOffset.FromUnixTimeSeconds(
                         long.Parse(ParseClaimsFromJwt(response.AccessToken).First(claim => claim.Type == "exp").Value));
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     //it's ok if we dont parse it, once auth fails we try again
                 }
             }
-            
-            
+
             _cache.AddOrReplace(CacheKey, response);
             return response.AccessToken;
         }

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubClient.cs
@@ -130,7 +130,7 @@ namespace BTCPayServer.Lightning.LndHub
 
             var req = new HttpRequestMessage
             {
-                RequestUri = new Uri($"{_baseUri}{path}"),
+                RequestUri = new Uri($"{WithTrailingSlash(_baseUri.ToString())}{path}"),
                 Method = method,
                 Content = content
             };

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
@@ -120,8 +120,9 @@ namespace BTCPayServer.Lightning.LndHub
 
         private void Dispose(bool waitLoop)
         {
-            if(_cts.IsCancellationRequested)
+            if (_cts.IsCancellationRequested)
                 return;
+            _cts.Cancel();
             _reader?.Dispose();
             _reader = null;
             _body?.Dispose();

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
@@ -30,7 +30,6 @@ namespace BTCPayServer.Lightning.LndHub
             _client = lndHubClient;
             _paidInvoiceIds = new List<string>();
             _listenLoop = ListenLoop();
-            
         }
 
         public async Task<LightningInvoice> WaitInvoice(CancellationToken cancellation)
@@ -60,7 +59,6 @@ namespace BTCPayServer.Lightning.LndHub
         
         private async Task ListenLoop()
         {
-            
             try
             {
                 var releaser = await  _locker.LockOrBustAsync(_client.CacheKey, _cts.Token);
@@ -70,7 +68,7 @@ namespace BTCPayServer.Lightning.LndHub
                     {
                         if (_activeListeners.TryGetValue(_client.CacheKey, out var invoicesData))
                         {
-                            await HandleInvociesData(invoicesData);
+                            await HandleInvoicesData(invoicesData);
                         }
                         releaser = await  _locker.LockOrBustAsync(_client.CacheKey, _cts.Token);
                         
@@ -85,7 +83,7 @@ namespace BTCPayServer.Lightning.LndHub
                     {
                         var invoicesData = await _client.GetInvoices(_cts.Token);
                         _activeListeners.AddOrReplace(_client.CacheKey, invoicesData);
-                        await HandleInvociesData(invoicesData);
+                        await HandleInvoicesData(invoicesData);
 
                         await Task.Delay(2500, _cts.Token);
                     }
@@ -105,7 +103,7 @@ namespace BTCPayServer.Lightning.LndHub
             }
         }
 
-        private async Task HandleInvociesData(InvoiceData[] invoicesData)
+        private async Task HandleInvoicesData(IEnumerable<InvoiceData> invoicesData)
         {
             foreach (var data in invoicesData)
             {

--- a/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/LndHubInvoiceListener.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -6,14 +7,16 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
+using BTCPayServer.Lightning.LNDhub.Models;
+using NBitcoin;
 
 namespace BTCPayServer.Lightning.LndHub
 {
     public class LndHubInvoiceListener : ILightningInvoiceListener
     {
         private readonly LndHubClient _client;
-        private readonly Channel<LightningInvoice> _invoices = Channel.CreateBounded<LightningInvoice>(50);
-        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly Channel<LightningInvoice> _invoices = Channel.CreateUnbounded<LightningInvoice>();
+        private readonly CancellationTokenSource _cts;
         private HttpClient _httpClient;
         private HttpResponseMessage _response;
         private Stream _body;
@@ -21,37 +24,13 @@ namespace BTCPayServer.Lightning.LndHub
         private Task _listenLoop;
         private readonly List<string> _paidInvoiceIds;
 
-        public LndHubInvoiceListener(LndHubClient lndHubClient)
+        public LndHubInvoiceListener(LndHubClient lndHubClient, CancellationToken cancellation)
         {
+            _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellation);
             _client = lndHubClient;
             _paidInvoiceIds = new List<string>();
-        }
-
-        public Task StartListening(string streamUrl, string accessToken, CancellationToken cancellation = default)
-        {
-            try
-            {
-                _listenLoop = ListenLoop();
-                
-                // FIXME: This websocket based version would work with LNDhub.go, see:
-                // https://ln.getalby.com/swagger/index.html#/Invoice/get_invoices_stream
-                /*
-                _httpClient = new HttpClient();
-                _httpClient.Timeout = TimeSpan.FromMilliseconds(Timeout.Infinite);
-                
-                var req = new HttpRequestMessage(HttpMethod.Get, streamUrl);
-                req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
-                req.Headers.Add("User-Agent", "BTCPayServer.Lightning.LndHubClient");
-
-                _listenLoop = ListenLoop(req, cancellation);
-                */
-            }
-            catch
-            {
-                Dispose();
-            }
+            _listenLoop = ListenLoop();
             
-            return Task.CompletedTask;
         }
 
         public async Task<LightningInvoice> WaitInvoice(CancellationToken cancellation)
@@ -76,26 +55,40 @@ namespace BTCPayServer.Lightning.LndHub
             Dispose(true);
         }
 
+        static readonly AsyncDuplicateLock _locker = new();
+        static readonly ConcurrentDictionary<string, InvoiceData[]> _activeListeners = new();
+        
         private async Task ListenLoop()
         {
+            
             try
             {
-                retry:
-                while (!_cts.IsCancellationRequested)
+                var releaser = await  _locker.LockOrBustAsync(_client.CacheKey, _cts.Token);
+                if (releaser is null)
                 {
-                    var invoicesData = await _client.GetInvoices(_cts.Token);
-                    foreach (var data in invoicesData)
+                    while (!_cts.IsCancellationRequested &&releaser is null)
                     {
-                        var invoice = LndHubUtil.ToLightningInvoice(data);
-                        if (invoice.PaidAt != null && !_paidInvoiceIds.Contains(invoice.Id))
+                        if (_activeListeners.TryGetValue(_client.CacheKey, out var invoicesData))
                         {
-                            await _invoices.Writer.WriteAsync(invoice, _cts.Token);
-                            _paidInvoiceIds.Add(invoice.Id);
+                            await HandleInvociesData(invoicesData);
                         }
+                        releaser = await  _locker.LockOrBustAsync(_client.CacheKey, _cts.Token);
+                        
+                        if(releaser is null)
+                            await Task.Delay(2500, _cts.Token);
                     }
+                }
 
-                    await Task.Delay(2500, _cts.Token);
-                    goto retry;
+                using (releaser)
+                {
+                    while (!_cts.IsCancellationRequested)
+                    {
+                        var invoicesData = await _client.GetInvoices(_cts.Token);
+                        _activeListeners.AddOrReplace(_client.CacheKey, invoicesData);
+                        await HandleInvociesData(invoicesData);
+
+                        await Task.Delay(2500, _cts.Token);
+                    }
                 }
             }
             catch when (_cts.IsCancellationRequested)
@@ -107,71 +100,28 @@ namespace BTCPayServer.Lightning.LndHub
             }
             finally
             {
+                _activeListeners.TryRemove(_client.CacheKey, out _);
                 Dispose(false);
             }
         }
 
-        // FIXME: This websocket based version would work with LNDhub.go, see:
-        // https://ln.getalby.com/swagger/index.html#/Invoice/get_invoices_stream
-        /*
-        private async Task ListenLoop(HttpRequestMessage request, CancellationToken cancellation = default)
+        private async Task HandleInvociesData(InvoiceData[] invoicesData)
         {
-            try
+            foreach (var data in invoicesData)
             {
-                _response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellation);
-                _body = await _response.Content.ReadAsStreamAsync();
-                _reader = new StreamReader(_body);
-                while(!cancellation.IsCancellationRequested)
+                var invoice = LndHubUtil.ToLightningInvoice(data);
+                if (invoice.PaidAt != null && !_paidInvoiceIds.Contains(invoice.Id))
                 {
-                    var line = await WithCancellation(_reader.ReadLineAsync(), cancellation);
-                    if (line == null) continue;
-                    
-                    if (line.StartsWith("{\"result\":", StringComparison.OrdinalIgnoreCase))
-                    {
-                        var invoiceString = JObject.Parse(line)["invoice"].ToString();
-                        var data = JsonConvert.DeserializeObject<InvoiceData>(invoiceString);
-                        var invoice = LndHubUtil.ToLightningInvoice(data);
-                        await _invoices.Writer.WriteAsync(invoice, cancellation);
-                    }
-                    else if (line.StartsWith("{\"error\":", StringComparison.OrdinalIgnoreCase))
-                    {
-                        throw new LndHubClient.LndHubApiException(line);
-                    }
-                    else
-                    {
-                        throw new LndHubClient.LndHubApiException("Unknown result from LNDHub: " + line);
-                    }
+                    await _invoices.Writer.WriteAsync(invoice, _cts.Token);
+                    _paidInvoiceIds.Add(invoice.Id);
                 }
             }
-            catch when(cancellation.IsCancellationRequested)
-            {
-            }
-            catch(Exception ex)
-            {
-                _invoices.Writer.TryComplete(ex);
-            }
-            finally
-            {
-                Dispose(false);
-            }
         }
-
-        private static async Task<T> WithCancellation<T>(Task<T> task, CancellationToken cancellationToken)
-        {
-            using var delayCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            var waiting = Task.Delay(-1, delayCts.Token);
-            await Task.WhenAny(waiting, task);
-            delayCts.Cancel();
-            cancellationToken.ThrowIfCancellationRequested();
-            return await task;
-        }
-        */
 
         private void Dispose(bool waitLoop)
         {
             if(_cts.IsCancellationRequested)
                 return;
-            _cts.Cancel();
             _reader?.Dispose();
             _reader = null;
             _body?.Dispose();

--- a/src/BTCPayServer.Lightning.LNDhub/Models/AuthResponse.cs
+++ b/src/BTCPayServer.Lightning.LNDhub/Models/AuthResponse.cs
@@ -1,3 +1,4 @@
+using System;
 using Newtonsoft.Json;
 
 namespace BTCPayServer.Lightning.LNDhub.Models
@@ -9,5 +10,8 @@ namespace BTCPayServer.Lightning.LNDhub.Models
         
         [JsonProperty("refresh_token")]
         public string RefreshToken { get; set; }
+        
+        [JsonProperty("expiry")]
+        public DateTimeOffset? Expiry { get; set; }
     }
 }

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -473,7 +473,7 @@ retry:
                 {
                     if (realException != null)
                         Logs.Tester.LogInformation(realException.ToString());
-                    Assert.False(true, $"{name}: The server could not be started");
+                    Assert.Fail($"{name}: The server could not be started");
                 }
             }
         }
@@ -764,7 +764,7 @@ retry:
                 await Task.Delay(100, waitToken);
                 listener.Dispose();
                 Logs.Tester.LogInformation($"{test.Name}: Listener disposed, should throw exception");
-                Assert.Throws<OperationCanceledException>(() => waitTask3.GetAwaiter().GetResult());
+                await Assert.ThrowsAsync<OperationCanceledException>(async () => await waitTask3);
             }
         }
 


### PR DESCRIPTION
This option is so popular that is was ddosing Alby. We had some severe exessive roundtrips. This PR:
* Caches the access token/refresh token in memory, and the expiry time is extracted from the access token.
* If the expiry is close (5mins), we use the refresh token to get a new access token
* If there are multiple clients using the same user (url and credentials), it reuses the access token instead of asking for a new one
* If there are multiple invoice watchers, only one will actively request invoices, while the others will read from cache. As soon as it is inactive, another switches to fetching the invoices.