### PR TITLE
Eclair: Catch all connection exceptions

### DIFF
--- a/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Eclair/EclairLightningClient.cs
@@ -430,7 +430,7 @@ namespace BTCPayServer.Lightning.Eclair
                     return ConnectionResult.Ok;
                 return ConnectionResult.CouldNotConnect;
             }
-            catch (EclairClient.EclairApiException)
+            catch (Exception)
             {
                 return ConnectionResult.CouldNotConnect;
             }


### PR DESCRIPTION
Supposed to fix this test error:

```
  Failed BTCPayServer.Lightning.Tests.CommonTests.DoNotReportOkIfChannelCantConnect [1 m 45 s]
  Error Message:
   System.Threading.Tasks.TaskCanceledException : The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing.
---- System.TimeoutException : The operation was canceled.
-------- System.Threading.Tasks.TaskCanceledException : The operation was canceled.
------------ System.IO.IOException : Unable to read data from the transport connection: Operation canceled.
---------------- System.Net.Sockets.SocketException : Operation canceled
```