### PR TITLE
Bumping LND to 0.17.4-beta-rc1

### DIFF
--- a/tests/BTCPayServer.Lightning.Tests.csproj
+++ b/tests/BTCPayServer.Lightning.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
-	  <LangVersion>12</LangVersion>
+	  <LangVersion>10</LangVersion> 
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -112,7 +112,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta-rc1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -147,7 +147,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.3-beta
+    image: btcpayserver/lnd:v0.17.4-beta-rc1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.17.4-beta-rc1/images/sha256-26f86b586d691680bfe56b796394bdd7e1900d1fb095947fbe5d3e22fb30d0bd?context=explore

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.17.4-beta-rc1