### PR TITLE
Bumping LND to 0.18.0-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -114,7 +114,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.4-beta
+    image: btcpayserver/lnd:v0.18.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -149,7 +149,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.17.4-beta
+    image: btcpayserver/lnd:v0.18.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.18.0-beta/images/sha256-e6043dddf0bdbd5c740e882447c441b37f87f2c736ebb08747a4aff5e100d9bf?context=repo

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.18.0-beta