### PR TITLE
Bumping LND to 0.18.1-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -114,7 +114,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.0-beta
+    image: btcpayserver/lnd:v0.18.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -149,7 +149,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.0-beta
+    image: btcpayserver/lnd:v0.18.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.18.1-beta/images/sha256-5fbfa76a218ab59bf9206485f4c0c071a525f9f0906255a5672054741d043b79?context=repo

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.18.1-beta