### PR TITLE
Bumping LND to 0.18.3-beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ jobs:
   build:
     machine:
       enabled: true
-      image: ubuntu-2004:202201-02
+      image: default
     steps:
       - checkout
 
   test:
     machine:
       enabled: true
-      image: ubuntu-2004:202201-02
+      image: default
     steps:
       - checkout
       - run:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -114,7 +114,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.1-beta
+    image: btcpayserver/lnd:v0.18.3-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -149,7 +149,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.1-beta
+    image: btcpayserver/lnd:v0.18.3-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.18.3-beta/images/sha256-e7449187b058440e4746f948bd095584d67bb82133c93737204e86c3aeff664a?context=repo

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.18.3-beta