### PR TITLE
Bumping LND to 0.18.4-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -114,7 +114,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -149,7 +149,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.3-beta
+    image: btcpayserver/lnd:v0.18.4-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/layers/btcpayserver/lnd/v0.18.4-beta/images/sha256-ead59bbc8c9ea3dc76fc4122b31c12bd3b5f86acd7416ac42c0c4fc010f2d25e

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.18.4-beta