### PR TITLE
Bumping LND to 0.18.5-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:24.0
+    image: btcpayserver/bitcoin:27.1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_WALLETDIR: "/data/wallets"
@@ -114,7 +114,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.4-beta
+    image: btcpayserver/lnd:v0.18.5-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -149,7 +149,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.18.4-beta
+    image: btcpayserver/lnd:v0.18.5-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.18.5-beta/sha256-61ee37ef066024088531e4b26971590f1b7d131fc824fa3443cba70f782d0d30

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.18.5-beta