### PR TITLE
feat: Expose a Liquidity class to measure and report inbound Lightning capacity

### DIFF
--- a/src/BTCPayServer.Lightning.Common/Liquidity.cs
+++ b/src/BTCPayServer.Lightning.Common/Liquidity.cs
@@ -1,12 +1,94 @@
 using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using BTCPayServer.Lightning.JsonConverters;
+using Newtonsoft.Json;
 
 namespace BTCPayServer.Lightning
 {
-    public class Liquidity
+    /// <summary>
+    /// Overall inbound-liquidity health.
+    /// </summary>
+    public enum LiquidityStatus
     {
-        public static string HelloWorld()
+        Good,
+        Pending,
+        Bad
+    }
+
+    /// <summary>
+    /// DTO returned when liquidity could be analysed.
+    /// </summary>
+    public class LiquidityReport
+    {
+        public LiquidityStatus Liquidity_Status { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney Active_Inbound_Satoshis { get; set; }
+
+        [JsonConverter(typeof(LightMoneyJsonConverter))]
+        public LightMoney Pending_Inbound_Satoshis { get; set; }
+    }
+
+    /// <summary>
+    /// Helper for checking Core-Lightning inbound liquidity without introducing
+    /// a compile-time dependency on BTCPayServer.Lightning.CLightning.*.
+    /// </summary>
+    public static class Liquidity
+    {
+        private static readonly LightMoney DefaultThreshold = LightMoney.Satoshis(250_000);
+
+        /// <summary>
+        /// Returns <c>null</c> when the supplied node is not Core-Lightning or
+        /// if an error occurs; otherwise returns a populated <see cref="LiquidityReport"/>.
+        /// </summary>
+        public static async Task<LiquidityReport?> CheckAsync(
+            ILightningClient client,
+            ILogger?         logger      = null,
+            LightMoney?      threshold   = null,
+            CancellationToken token      = default)
         {
-            return "Hello World from BTCPayServer.Lightning.Common.Liquidity! - UPDATED";
+            // Runtime check – keeps Common free of a direct CLightning reference.
+            if (!client.GetType().Name.Equals("CLightningClient", StringComparison.Ordinal))
+                return null;
+
+            var min = threshold ?? DefaultThreshold;
+
+            try
+            {
+                var channels = await client.ListChannels(token);
+
+                // inbound capacity = total – local
+                LightMoney activeInbound  = channels.Where(c => c.IsActive)
+                                                    .Aggregate(LightMoney.Zero,
+                                                               (s, ch) => s + (ch.Capacity - ch.LocalBalance));
+
+                LightMoney pendingInbound = channels.Where(c => !c.IsActive)
+                                                    .Aggregate(LightMoney.Zero,
+                                                               (s, ch) => s + (ch.Capacity - ch.LocalBalance));
+
+                var status = LiquidityStatus.Bad;
+                if (activeInbound >= min)
+                    status = LiquidityStatus.Good;
+                else if (pendingInbound >= min)
+                    status = LiquidityStatus.Pending;
+
+                return new LiquidityReport
+                {
+                    Liquidity_Status          = status,
+                    Active_Inbound_Satoshis   = activeInbound,
+                    Pending_Inbound_Satoshis  = pendingInbound
+                };
+            }
+            catch (Exception ex)
+            {
+                // Works with the ILogger overloads available in netstandard2.0.
+                logger?.LogWarning("[Liquidity] check failed: {Exception}", ex);
+                return null;
+            }
         }
     }
 }

--- a/src/BTCPayServer.Lightning.Common/Liquidity.cs
+++ b/src/BTCPayServer.Lightning.Common/Liquidity.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BTCPayServer.Lightning
+{
+    public class Liquidity
+    {
+        public static string HelloWorld()
+        {
+            return "Hello World from BTCPayServer.Lightning.Common.Liquidity! - UPDATED";
+        }
+    }
+}


### PR DESCRIPTION
This supports a pull request against BTCPayserver ( https://github.com/btcpayserver/btcpayserver/pull/6824 ) which will allow users to know when their attached Lightning node lacks inbound capacity (liquidity). 

Currently this only works with c-lightning, however, if there is interest, this could be extended to also report this data from LND. 