### PR TITLE
Bumping LND to 0.19.3-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -114,7 +114,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.1-beta
+    image: btcpayserver/lnd:v0.19.3-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -149,7 +149,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.1-beta
+    image: btcpayserver/lnd:v0.19.3-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Updating to newest release: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.19.3-beta/sha256-6115e7ce3bd1065c602ac77d252803db79d29b82f301c6cd61b0a63ecc5a9642

Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.19.3-beta