### PR TITLE
lnd: support amountless bolt11 invoice creation

### DIFF
--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -350,12 +350,14 @@ namespace BTCPayServer.Lightning.LND
         }
         public async Task<LightningInvoice> CreateInvoice(CreateInvoiceParams req, CancellationToken cancellation = default)
         {
-            var strAmount = ConvertInv.ToString(req.Amount.ToUnit(LightMoneyUnit.MilliSatoshi));
             var strExpiry = ConvertInv.ToString(Math.Round(req.Expiry.TotalSeconds, 0));
 
             var lndRequest = new LnrpcInvoice
             {
-                ValueMSat = strAmount,
+                // null → field omitted from JSON (NullValueHandling.Ignore) → LND produces amountless bolt11
+                ValueMSat = req.Amount == LightMoney.Zero
+                    ? null
+                    : ConvertInv.ToString(req.Amount.ToUnit(LightMoneyUnit.MilliSatoshi)),
                 Memo = req.Description,
                 Description_hash = req.DescriptionHash?.ToBytes(false),
                 Expiry = strExpiry,


### PR DESCRIPTION
## Summary

This PR makes a small, targeted change to `LndClient.CreateInvoice` so that passing `LightMoney.Zero` as the amount produces a valid **amountless BOLT11 invoice** — one where the payer can send any amount they choose.

**The change:** when `req.Amount == LightMoney.Zero`, we now set `ValueMSat = null` instead of `ValueMSat = "0"`. Because `LnrpcInvoice.ValueMSat` is already decorated with `NullValueHandling.Ignore` in `LndSwaggerClient.cs`, a `null` value is silently omitted from the serialized JSON body sent to LND.

```diff
- var strAmount = ConvertInv.ToString(req.Amount.ToUnit(LightMoneyUnit.MilliSatoshi));
  var lndRequest = new LnrpcInvoice
  {
-     ValueMSat = strAmount,
+     // null → field omitted from JSON (NullValueHandling.Ignore) → LND produces amountless bolt11
+     ValueMSat = req.Amount == LightMoney.Zero
+         ? null
+         : ConvertInv.ToString(req.Amount.ToUnit(LightMoneyUnit.MilliSatoshi)),
```

---

## Why This Is Safe

### LND natively supports this — by design

This is intentional, long-standing LND behaviour. From [`lnrpc/invoicesrpc/addinvoice.go`](https://github.com/lightningnetwork/lnd/blob/v0.19.3-beta/lnrpc/invoicesrpc/addinvoice.go#L340):

```go
// We only include the amount in the invoice if it is greater than 0.
// By not including the amount, we enable the creation of invoices that
// allow the payer to specify the amount of satoshis they wish to send.
if amtMSat > 0 {
    options = append(options, zpay32.Amount(amtMSat))
}
```

This logic exists in every LND release and is not version-specific. Omitting `value_msat` from the request body is the documented way to create an amountless invoice.

### No breaking changes anywhere

- `LightMoney.Zero` was never a meaningful invoice amount before — no existing caller passes it expecting a zero-sat invoice.
- All other `LndClient` methods are completely untouched.
- No changes to `ILightningClient`, `CreateInvoiceParams`, or any other backend (`CLightning`, `Eclair`, `Phoenixd`, `LNDhub`, `Charge`).
- The `NullValueHandling.Ignore` attribute on `ValueMSat` was already there — this PR simply takes advantage of it.

---

## Full Plan for the Follow-up PR in `btcpayserver`

Once this is merged and a new `BTCPayServer.Lightning.All` NuGet version is published, a follow-up PR to the main [`btcpayserver`](https://github.com/btcpayserver/btcpayserver) repo will make the following changes to `BTCPayServer/Payments/Lightning/LightningLikePaymentHandler.cs`:

**1. Make the TopUp rejection LND-aware**

Currently `ConfigurePrompt` unconditionally throws for any `InvoiceType.TopUp`:

```csharp
// current code
if (context.InvoiceEntity.Type == InvoiceType.TopUp)
    throw new PaymentMethodUnavailableException("Lightning Network payment method is not available for top-up invoices");
```

It will become:

```csharp
// after change — only non-LND backends throw
var isTopUp = context.InvoiceEntity.Type == InvoiceType.TopUp;
if (isTopUp && client is not BTCPayServer.Lightning.LND.LndClient)
    throw new PaymentMethodUnavailableException("Lightning Network payment method is not available for top-up invoices");
```

This pattern already exists in the codebase — `LightningListener.cs` and `LightningLikePaymentHandler.cs` both type-check for `LndClient` and `LndHubLightningClient` today.

**2. Pass `LightMoney.Zero` for TopUp invoices**

```csharp
// For LND TopUp: LightMoney.Zero triggers the amountless bolt11 path added in this PR
var invoiceAmount = isTopUp ? LightMoney.Zero : new LightMoney(due, LightMoneyUnit.BTC);
var request = new CreateInvoiceParams(invoiceAmount, description, expiry);
```

**3. Skip the amount-diff fee-tweak check for amountless invoices**

```csharp
if (!isTopUp)
{
    var diff = request.Amount - lightningInvoice.Amount;
    if (diff != LightMoney.Zero)
        paymentPrompt.AddTweakFee(-diff.ToUnit(LightMoneyUnit.BTC));
}
```

**No changes needed to `LightningListener.cs`** — `ConvertLndInvoice` already maps `ValueMSat = "0"` to `LightMoney(0)` (not `null`), so the existing `notification.Amount != null` guard passes correctly. `AddPayment` already uses `notification.AmountReceived ?? notification.Amount` to capture the actual paid amount.

### What this unlocks for users

Stores configured with LND as their lightning backend will get a working **BTC-LN tab on top-up invoices** (open-amount invoices), alongside the existing BTC-CHAIN and BTC-LNURL tabs. All other lightning backends (CLN, Eclair, Phoenixd, etc.) are completely unaffected and continue to show the existing "not available for top-up" behaviour.
