### PR TITLE
Bumping LND to 0.19.3-beta-1

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -114,7 +114,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.3-beta
+    image: btcpayserver/lnd:v0.19.3-beta-1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -149,7 +149,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.3-beta
+    image: btcpayserver/lnd:v0.19.3-beta-1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.19.3-beta-1
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.19.3-beta-1