### PR TITLE
Various improvement to Phoenixd backend

### DIFF
--- a/src/BTCPayServer.Lightning.Phoenixd/Models/CreateInvoiceRequest.cs
+++ b/src/BTCPayServer.Lightning.Phoenixd/Models/CreateInvoiceRequest.cs
@@ -7,6 +7,9 @@ namespace BTCPayServer.Lightning.Phoenixd.Models
         [JsonProperty("description")]
         public string Description { get; set; }
 
+        [JsonProperty("descriptionHash")]
+        public string DescriptionHash { get; set; }
+
         [JsonProperty("amountSat")]
         public long? AmountSat { get; set; }
 

--- a/src/BTCPayServer.Lightning.Phoenixd/Models/GetIncomingPaymentResponse.cs
+++ b/src/BTCPayServer.Lightning.Phoenixd/Models/GetIncomingPaymentResponse.cs
@@ -26,6 +26,12 @@ namespace BTCPayServer.Lightning.Phoenixd.Models
         [JsonProperty("isPaid")]
         public bool IsPaid { get; set; }
 
+        [JsonProperty("isExpired")]
+        public bool IsExpired { get; set; }
+
+        [JsonProperty("requestedSat")]
+        public long? RequestedSat { get; set; }
+
         [JsonProperty("receivedSat")]
         public long ReceivedSat { get; set; }
 
@@ -34,10 +40,14 @@ namespace BTCPayServer.Lightning.Phoenixd.Models
 
         [JsonProperty("completedAt")]
         [JsonConverter(typeof(PhoenixdDateTimeJsonConverter))]
-        public DateTimeOffset CompletedAt { get; set; }
+        public DateTimeOffset? CompletedAt { get; set; }
+
+        [JsonProperty("expiresAt")]
+        [JsonConverter(typeof(PhoenixdDateTimeJsonConverter))]
+        public DateTimeOffset? ExpiresAt { get; set; }
 
         [JsonProperty("createdAt")]
         [JsonConverter(typeof(PhoenixdDateTimeJsonConverter))]
-        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset? CreatedAt { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.Phoenixd/Models/GetInfoResponse.cs
+++ b/src/BTCPayServer.Lightning.Phoenixd/Models/GetInfoResponse.cs
@@ -7,6 +7,9 @@ public class GetInfoResponse
     [JsonProperty("nodeId")]
     public string NodeId { get; set; }
 
+    [JsonProperty("channels")]
+    public GetInfoChannel[] Channels { get; set; }
+
     [JsonProperty("chain")]
     public string Chain { get; set; }
 
@@ -15,4 +18,10 @@ public class GetInfoResponse
 
     [JsonProperty("version")]
     public string Version { get; set; }
+}
+
+public class GetInfoChannel
+{
+    [JsonProperty("state")]
+    public string State { get; set; }
 }

--- a/src/BTCPayServer.Lightning.Phoenixd/Models/GetOutgoingPaymentResponse.cs
+++ b/src/BTCPayServer.Lightning.Phoenixd/Models/GetOutgoingPaymentResponse.cs
@@ -8,6 +8,9 @@ namespace BTCPayServer.Lightning.Phoenixd.Models
 {
     public class GetOutgoingPaymentResponse
     {
+        [JsonProperty("paymentId")]
+        public string paymentId { get; set; }
+
         [JsonProperty("paymentHash")]
         public string paymentHash { get; set; }
 
@@ -28,10 +31,10 @@ namespace BTCPayServer.Lightning.Phoenixd.Models
 
         [JsonProperty("completedAt")]
         [JsonConverter(typeof(PhoenixdDateTimeJsonConverter))]
-        public DateTimeOffset completedAt { get; set; }
+        public DateTimeOffset? completedAt { get; set; }
 
         [JsonProperty("createdAt")]
         [JsonConverter(typeof(PhoenixdDateTimeJsonConverter))]
-        public DateTimeOffset createdAt { get; set; }
+        public DateTimeOffset? createdAt { get; set; }
     }
 }

--- a/src/BTCPayServer.Lightning.Phoenixd/PhoenixdClient.cs
+++ b/src/BTCPayServer.Lightning.Phoenixd/PhoenixdClient.cs
@@ -50,12 +50,13 @@ namespace BTCPayServer.Lightning.Phoenixd
 
         public async Task<CreateInvoiceResponse> CreateInvoice(string description, long? amountSat = null,
             int? expirySeconds = null, BitcoinAddress fallbackAddress = null,
-            CancellationToken cts = default)
+            string descriptionHash = null, CancellationToken cts = default)
         {
             return await SendCommandAsync<CreateInvoiceRequest, CreateInvoiceResponse>("createinvoice",
                 new CreateInvoiceRequest
                 {
                     Description = description,
+                    DescriptionHash = descriptionHash,
                     ExpirySeconds = expirySeconds,
                     AmountSat = amountSat == 0 ? null : amountSat
                 }, cts);
@@ -77,10 +78,43 @@ namespace BTCPayServer.Lightning.Phoenixd
             return await SendCommandAsync<NoRequestModel, GetIncomingPaymentResponse>($"payments/incoming/{paymentHash}", NoRequestModel.Instance, cts, true);
         }
 
+        public async Task<GetIncomingPaymentResponse[]> ListIncomingPayments(bool all = false, long? offset = null,
+            int? limit = null, CancellationToken cts = default)
+        {
+            var query = new Dictionary<string, string>();
+            if (all)
+                query.Add("all", "true");
+            if (offset is not null)
+                query.Add("offset", offset.Value.ToString());
+            if (limit is not null)
+                query.Add("limit", limit.Value.ToString());
+            return await SendCommandAsync<NoRequestModel, GetIncomingPaymentResponse[]>("payments/incoming" + BuildQuery(query), NoRequestModel.Instance, cts, true);
+        }
+
         public async Task<GetOutgoingPaymentResponse> GetOutgoingPayment(string paymentHash, string invoice = null,
             CancellationToken cts = default)
         {
             return await SendCommandAsync<NoRequestModel, GetOutgoingPaymentResponse>($"payments/outgoingbyhash/{paymentHash}", NoRequestModel.Instance, cts, true);
+        }
+
+        public async Task<GetOutgoingPaymentResponse[]> ListOutgoingPayments(bool all = false, long? offset = null,
+            int? limit = null, CancellationToken cts = default)
+        {
+            var query = new Dictionary<string, string>();
+            if (all)
+                query.Add("all", "true");
+            if (offset is not null)
+                query.Add("offset", offset.Value.ToString());
+            if (limit is not null)
+                query.Add("limit", limit.Value.ToString());
+            return await SendCommandAsync<NoRequestModel, GetOutgoingPaymentResponse[]>("payments/outgoing" + BuildQuery(query), NoRequestModel.Instance, cts, true);
+        }
+
+        private static string BuildQuery(Dictionary<string, string> query)
+        {
+            if (query.Count == 0)
+                return string.Empty;
+            return "?" + string.Join("&", query.Select(pair => $"{Uri.EscapeDataString(pair.Key)}={Uri.EscapeDataString(pair.Value)}"));
         }
 
         public async Task<string> SendPayment(string address, long amountSat, long feerateSat,

--- a/src/BTCPayServer.Lightning.Phoenixd/PhoenixdLightningClient.cs
+++ b/src/BTCPayServer.Lightning.Phoenixd/PhoenixdLightningClient.cs
@@ -40,33 +40,50 @@ namespace BTCPayServer.Lightning.Phoenixd
             {
             }
 
-            if (info != null && info.PaymentHash != "")
+            return ToLightningInvoice(info);
+        }
+
+        private LightningInvoice ToLightningInvoice(GetIncomingPaymentResponse info)
+        {
+            if (info == null || string.IsNullOrEmpty(info.PaymentHash) || string.IsNullOrEmpty(info.Invoice))
+                return null;
+
+            var parsed = BOLT11PaymentRequest.Parse(info.Invoice, _network);
+            return new LightningInvoice
             {
-                var parsed = BOLT11PaymentRequest.Parse(info.Invoice, _network);
-                var invoiceId = info.PaymentHash;
-                var lnInvoice = new LightningInvoice
-                {
-                    Id = invoiceId,
-                    PaymentHash = info.PaymentHash,
-                    Amount = parsed.MinimumAmount,
-                    ExpiresAt = parsed.ExpiryDate,
-                    BOLT11 = info.Invoice
-                };
-                if (DateTimeOffset.UtcNow >= parsed.ExpiryDate)
-                {
-                    lnInvoice.Status = LightningInvoiceStatus.Expired;
-                }
-                // In lightning fees are typically paid by the sender,
-                // but phoenixd charges a fee to the recipient when
-                // e.g. opening a channel. Include fee in AmountReceive
-                // so it's not marked as incomplete.
-                lnInvoice.AmountReceived = LightMoney.Satoshis(info.ReceivedSat) + new LightMoney(info.Fees, LightMoneyUnit.MilliSatoshi);
-                lnInvoice.Status = info.IsPaid ? LightningInvoiceStatus.Paid : LightningInvoiceStatus.Unpaid;
-                lnInvoice.PaidAt = info.CompletedAt;
-                lnInvoice.Preimage = info.PreImage;
-                return lnInvoice;
-            }
-            return null;
+                Id = info.PaymentHash,
+                PaymentHash = info.PaymentHash,
+                Amount = parsed.MinimumAmount,
+                ExpiresAt = info.ExpiresAt ?? parsed.ExpiryDate,
+                BOLT11 = info.Invoice,
+                // Phoenixd may charge recipient liquidity fees; include them so the invoice is not considered underpaid.
+                AmountReceived = LightMoney.Satoshis(info.ReceivedSat) + new LightMoney(info.Fees, LightMoneyUnit.MilliSatoshi),
+                Status = info.IsPaid ? LightningInvoiceStatus.Paid :
+                    (info.IsExpired || DateTimeOffset.UtcNow >= parsed.ExpiryDate ? LightningInvoiceStatus.Expired : LightningInvoiceStatus.Unpaid),
+                PaidAt = info.CompletedAt,
+                Preimage = info.PreImage
+            };
+        }
+
+        private LightningPayment ToLightningPayment(GetOutgoingPaymentResponse info)
+        {
+            if (info == null || string.IsNullOrEmpty(info.paymentHash))
+                return null;
+
+            var fee = new LightMoney(info.fees, LightMoneyUnit.MilliSatoshi);
+            var sent = LightMoney.Satoshis(info.sent);
+            return new LightningPayment
+            {
+                Id = info.paymentId,
+                Preimage = info.preImage,
+                PaymentHash = info.paymentHash,
+                CreatedAt = info.createdAt,
+                Amount = sent,
+                AmountSent = sent + fee,
+                Fee = fee,
+                BOLT11 = info.invoice,
+                Status = info.isPaid ? LightningPaymentStatus.Complete : LightningPaymentStatus.Unknown
+            };
         }
 
         public PhoenixdLightningClient(Uri address, string password, Network network, HttpClient httpClient = null) :
@@ -103,9 +120,14 @@ namespace BTCPayServer.Lightning.Phoenixd
         public async Task<LightningInvoice> GetInvoice(uint256 paymentHash, CancellationToken cancellation = default) =>
             await GetInvoice(paymentHash.ToString(), cancellation);
 
-        public Task<LightningInvoice[]> ListInvoices(ListInvoicesParams request, CancellationToken cancellation = default)
+        public async Task<LightningInvoice[]> ListInvoices(ListInvoicesParams request, CancellationToken cancellation = default)
         {
-            throw new NotSupportedException();
+            request ??= new ListInvoicesParams();
+            var incoming = await _PhoenixdClient.ListIncomingPayments(true, request.OffsetIndex, 100, cancellation);
+            var invoices = incoming.Select(ToLightningInvoice).Where(i => i != null);
+            if (request.PendingOnly is true)
+                invoices = invoices.Where(i => i.Status == LightningInvoiceStatus.Unpaid);
+            return invoices.ToArray();
         }
 
         public async Task<LightningInvoice[]> ListInvoices(CancellationToken cancellation = default) =>
@@ -113,41 +135,38 @@ namespace BTCPayServer.Lightning.Phoenixd
 
         public async Task<LightningPayment> GetPayment(string paymentHash, CancellationToken cancellation = default)
         {
-            GetOutgoingPaymentResponse info = await _PhoenixdClient.GetOutgoingPayment(paymentHash, null, cancellation);
-            var payment = new LightningPayment
+            try
             {
-                Preimage = info.preImage,
-                PaymentHash = info.paymentHash,
-                CreatedAt = info.createdAt,
-                Amount = new LightMoney(info.sent, LightMoneyUnit.Satoshi),
-                AmountSent = new LightMoney(info.sent + info.fees, LightMoneyUnit.Satoshi),
-                Fee = new LightMoney(info.fees, LightMoneyUnit.Satoshi),
-                Status = info.isPaid ? LightningPaymentStatus.Complete : LightningPaymentStatus.Unknown
-            };
-
-            return payment;
+                return ToLightningPayment(await _PhoenixdClient.GetOutgoingPayment(paymentHash, null, cancellation));
+            }
+            catch (PhoenixdClient.PhoenixdApiException)
+            {
+                return null;
+            }
         }
 
-        public Task<LightningPayment[]> ListPayments(CancellationToken cancellation = default)
+        public async Task<LightningPayment[]> ListPayments(CancellationToken cancellation = default) =>
+            await ListPayments(null, cancellation);
+
+        public async Task<LightningPayment[]> ListPayments(ListPaymentsParams request, CancellationToken cancellation = default)
         {
-            throw new NotSupportedException();
+            request ??= new ListPaymentsParams();
+            var outgoing = await _PhoenixdClient.ListOutgoingPayments(request.IncludePending is true, request.OffsetIndex, 100, cancellation);
+            return outgoing.Select(ToLightningPayment).Where(p => p != null).ToArray();
         }
 
-        public Task<LightningPayment[]> ListPayments(ListPaymentsParams request, CancellationToken cancellation = default)
-        {
-            throw new NotSupportedException();
-        }
-
-        async Task<LightningInvoice> ILightningClient.CreateInvoice(LightMoney amount, string description, TimeSpan expiry,
+        Task<LightningInvoice> ILightningClient.CreateInvoice(LightMoney amount, string description, TimeSpan expiry,
             CancellationToken cancellation)
-        {
-            var result = await _PhoenixdClient.CreateInvoice(
-                description,
-                amount.MilliSatoshi / 1000,
-                Convert.ToInt32(expiry.TotalSeconds), null, cancellation);
+            => (this as ILightningClient).CreateInvoice(new CreateInvoiceParams(amount, description, expiry),
+                cancellation);
 
+        async Task<LightningInvoice> ILightningClient.CreateInvoice(CreateInvoiceParams req, CancellationToken cancellation)
+        {
+            var result = await _PhoenixdClient.CreateInvoice(req.DescriptionHash is null ? req.Description : null,
+                req.Amount.MilliSatoshi / 1000, Convert.ToInt32(req.Expiry.TotalSeconds), null,
+                req.DescriptionHash?.ToString(), cancellation);
             var parsed = BOLT11PaymentRequest.Parse(result.Serialized, _network);
-            var invoice = new LightningInvoice
+            return new LightningInvoice
             {
                 BOLT11 = result.Serialized,
                 Amount = LightMoney.Satoshis(result.AmountSat),
@@ -156,12 +175,6 @@ namespace BTCPayServer.Lightning.Phoenixd
                 ExpiresAt = parsed.ExpiryDate,
                 PaymentHash = result.PaymentHash
             };
-            return invoice;
-        }
-
-        Task<LightningInvoice> ILightningClient.CreateInvoice(CreateInvoiceParams req, CancellationToken cancellation)
-        {
-            return (this as ILightningClient).CreateInvoice(req.Amount, req.DescriptionHash is not null ? req.DescriptionHash.ToString() : req.Description, req.Expiry, cancellation);
         }
 
         public static async Task<ClientWebSocket> ClientWebSocket(string url, string authorizationValue, CancellationToken cancellation = default)
@@ -191,13 +204,18 @@ namespace BTCPayServer.Lightning.Phoenixd
             var network = _network.ToString();
             var info = await _PhoenixdClient.GetInfo(cancellation);
 
-            if (NormalizeChain(network) != NormalizeChain(info.Chain))
+            if (!string.IsNullOrEmpty(info.Chain) && NormalizeChain(network) != NormalizeChain(info.Chain))
                 throw new PhoenixdApiException { Error = new PhoenixdApiError { Error = $"Chain mismatch: BTCPay Server is using \"{network}\" while Phoenixd is configured for \"{info.Chain}\""} };
 
             var nodeInfo = new LightningNodeInformation
             {
                 BlockHeight = info.BlockHeight,
-                Version = info.Version
+                Version = info.Version,
+                Alias = "Phoenixd",
+                Color = "3399ff",
+                ActiveChannelsCount = info.Channels?.Count(c => c.State == "Normal"),
+                InactiveChannelsCount = info.Channels?.Count(c => c.State != "Normal"),
+                PendingChannelsCount = info.Channels?.Count(c => c.State != "Normal")
             };
             return nodeInfo;
         }


### PR DESCRIPTION
# Confirmed Findings

### 1. Expired status bug

The API returns `isExpired`, but the model does not map it, and the code overwrites `Expired` anyway. Add `IsExpired` to `GetIncomingPaymentResponse` and set status with `paid` first, then `expired`/`unpaid`.

### 2. Description hash support is currently broken

The API supports `descriptionHash`, but `CreateInvoiceRequest` only has `description`. `CreateInvoice(CreateInvoiceParams)` passes the hash as a plain description string. This should send `descriptionHash=<hex>` when `DescriptionHashOnly`/`DescriptionHash` is used.

### 3. Fee unit bug is definite

The API says the outgoing fees example is `4016` for a 4 sat routing fee, so outgoing fees are millisats. Existing code treats them as sats in `GetPayment`:

```csharp
new LightMoney(info.fees, LightMoneyUnit.Satoshi)
```

This should be `MilliSatoshi`.

Incoming fees appear to be sats from the docs examples, so `AmountReceived = receivedSat + fees(msat)` is suspicious and likely wrong unless incoming fees are documented elsewhere as msat.

### 4. `GetInfo` model is stale

The API `getinfo` no longer shows `chain`, `blockHeight`, or `version`; it shows `nodeId` and `channels`. Current `GetInfo` chain check may fail or compare empty/null data, and returned `LightningNodeInformation` misses the node ID.

It should at least populate `NodeInfoList` from `nodeId` if possible, and the network check probably needs another source, such as `/decodeinvoice`.

### 5. Missing list endpoints

The API supports `GET /payments/incoming` and `GET /payments/outgoing`, but `ListInvoices` and `ListPayments` throw `NotSupportedException`. This is not a bug if intentionally unimplemented, but Phoenixd can support them.

### 6. Unknown outgoing payment handling is still likely wrong

`GetPayment` should mirror `GetInvoice` and return `null` on not found, unless the API returns a non-error empty object. Current code throws on API errors.

# Changes Made

- Added Phoenixd 0.8.0 fields: `descriptionHash`, `isExpired`, `requestedSat`, `expiresAt`, `paymentId`, and `channels`.
- Fixed expired invoice status mapping so `Expired` is not overwritten by `Unpaid`.
- Fixed `CreateInvoice(CreateInvoiceParams)` to send `descriptionHash` instead of using the hash as plain text.
- Fixed outgoing payment fee units: Phoenixd outgoing history fees are now treated as millisats.
- `GetPayment` now returns `null` on Phoenixd API not-found errors.
- Implemented `ListInvoices` via `GET /payments/incoming`.
- Implemented `ListPayments` via `GET /payments/outgoing`.
- Relaxed `GetInfo` chain validation when Phoenixd 0.8.0 omits `chain`, and maps channel counts when present.
