### PR TITLE
Bumping LND to 0.21.0-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -128,7 +128,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.0-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.21.0-beta
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.21.0-beta