### PR TITLE
Fix BOLT11 feature bit overflow for feature bits at index 63 and above

### DIFF
--- a/src/BTCPayServer.Lightning.Common/BOLT11PaymentRequest.cs
+++ b/src/BTCPayServer.Lightning.Common/BOLT11PaymentRequest.cs
@@ -163,6 +163,7 @@ namespace BTCPayServer.Lightning
             var fallbackAddresses = new List<BitcoinAddress>();
             var routes = new List<RouteInformation>();
             var features = FeatureBits.None;
+            BitArray? rawFeatures = null;
             while (reader.Position != reader.Count - 520 - 30)
             {
                 AssertSize(5 + 10);
@@ -272,12 +273,23 @@ namespace BTCPayServer.Lightning
                         }
 
                         // Read which feature bits are set from right-to-left.
+                        // 'size' can advertise more feature bits than the strongly
+                        // typed FeatureBits enum (backed by a 64-bit integer) can
+                        // hold. A feature bit at index 63 or above cannot be
+                        // represented as a distinct enum flag: shifting by >= 64
+                        // wraps around in .NET and would set an unrelated, lower
+                        // feature bit (e.g. the trampoline placeholder bit 149 would
+                        // incorrectly set bit 21). Capture every advertised bit in
+                        // RawFeatureBits and only fold the representable ones into
+                        // the FeatureBits enum.
+                        rawFeatures = new BitArray(size);
                         for (var i = size - 1; i >= 0; i--)
                         {
-                            if (reader.Read())
-                            {
+                            if (!reader.Read())
+                                continue;
+                            rawFeatures[i] = true;
+                            if (i < 63)
                                 features |= (FeatureBits)((long) 1 << i);
-                            }
                         }
                         break;
                 }
@@ -296,6 +308,7 @@ namespace BTCPayServer.Lightning
             Routes = routes;
             FallbackAddresses = fallbackAddresses;
             FeatureBits = features;
+            RawFeatureBits = rawFeatures ?? new BitArray(0);
         }
 
         public bool VerifySignature()
@@ -396,6 +409,15 @@ namespace BTCPayServer.Lightning
         public uint256? PaymentSecret { get; }
         public DateTimeOffset ExpiryDate { get; }
         public FeatureBits FeatureBits { get; }
+
+        /// <summary>
+        /// All feature bits advertised by the invoice, indexed by feature bit number
+        /// (<c>RawFeatureBits[n]</c> is <c>true</c> when feature bit <c>n</c> is set).
+        /// Unlike <see cref="FeatureBits"/> — which is backed by a 64-bit enum and can
+        /// therefore only represent feature bits below 63 — this exposes every feature
+        /// bit, including large ones such as the trampoline placeholder (bit 149).
+        /// </summary>
+        public BitArray RawFeatureBits { get; }
 
         public static bool TryParse(string str, [MaybeNullWhen(false)] out BOLT11PaymentRequest? result, Network network)
         {

--- a/tests/CommonTests.cs
+++ b/tests/CommonTests.cs
@@ -790,6 +790,21 @@ retry:
             Assert.True((p.FeatureBits | (FeatureBits.MPPOptional | FeatureBits.PaymentAddrRequired | FeatureBits.TLVOnionPayloadOptional | FeatureBits.PaymentMetadataRequired)) ==
                         (FeatureBits.MPPOptional | FeatureBits.PaymentAddrRequired | FeatureBits.TLVOnionPayloadOptional | FeatureBits.PaymentMetadataRequired));
 
+            // Feature bits at index 63 or above must not overflow the 64-bit FeatureBits
+            // enum and corrupt unrelated low bits (issue #104). This invoice advertises
+            // feature bits 149 (trampoline placeholder, as used by ACINQ Phoenix), 15 and 9.
+            p = BOLT11PaymentRequest.Parse("lnbc1pj48ugq9q7sqqqqqqqqqqqqqqqqqqqqqqqqqpqsq0ek3nzu5qmahkcf28n2le2mgrz3argfyzqr96ha0yz9nedsah8uqrhg3fl24pyk0n2edx6ycpwznfmfp36qxvm2tam0kkzzy28wus4sqxryag5", Network.Main);
+            // The enum only carries the representable low bits (9 and 15)...
+            Assert.Equal(FeatureBits.TLVOnionPayloadOptional | FeatureBits.PaymentAddrOptional, p.FeatureBits);
+            // ...and no longer wraps bit 149 into the unrelated bit 21 (149 % 64 == 21).
+            Assert.Equal(0L, (long)p.FeatureBits & (1L << 21));
+            // RawFeatureBits preserves every advertised feature bit, including bit 149.
+            Assert.Equal(150, p.RawFeatureBits.Length);
+            Assert.True(p.RawFeatureBits[149]);
+            Assert.True(p.RawFeatureBits[15]);
+            Assert.True(p.RawFeatureBits[9]);
+            Assert.False(p.RawFeatureBits[21]);
+
             p = BOLT11PaymentRequest.Parse("lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp", Network.Main);
             Assert.Equal("lnbc", p.Prefix);
             Assert.Equal(9, p.MinFinalCLTVExpiry);


### PR DESCRIPTION
Fixes #104.

Feature bits advertised at index 63 or above overflowed the 64-bit `FeatureBits` enum. Because .NET masks a `long` shift count to `i & 63`, an invoice advertising e.g. the trampoline placeholder bit 149 used by ACINQ/Phoenix silently set the unrelated bit 21 (`149 % 64`) instead of being ignored.

This folds only the representable bits (`< 63`) into the `FeatureBits` enum and adds a `RawFeatureBits` (`BitArray`) property exposing every advertised feature bit, so high bits are preserved rather than corrupting low ones — matching the approach floated in the issue and endorsed by @dennisreimann. Existing behavior for representable bits is unchanged; the new property is purely additive and the enum type is never JSON-serialized.

Added a parse test (no node backend required) covering an invoice that advertises bit 149, verifying bit 21 is not set and `RawFeatureBits[149]` is. `dotnet build` and the parse/JSON tests pass.

— Prepared with AI assistance (Claude); reviewed and verified by the submitter. See `Co-Authored-By` trailer.
