### PR TITLE
fix: handle pending channels in channel listing

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -499,7 +499,7 @@ namespace BTCPayServer.Lightning.CLightning
 
         async Task<LightningChannel[]> ILightningClient.ListChannels(CancellationToken cancellation)
         {
-            var listChannels = await this.ListPeerChannelsAsync();
+            var listChannels = await this.ListPeerChannelsAsync(cancellation);
             List<LightningChannel> channels = new List<LightningChannel>();
             foreach (var channel in listChannels)
             {
@@ -508,7 +508,10 @@ namespace BTCPayServer.Lightning.CLightning
                     RemoteNode = new PubKey(channel.PeerId),
                     IsPublic = !channel.Private,
                     LocalBalance = channel.ToUs,
-                    ChannelPoint = new OutPoint(channel.FundingTxId, channel.ShortChannelId.TxOutIndex),
+                    // short_channel_id is not available until the funding transaction is confirmed.
+                    ChannelPoint = channel.FundingTxId is null || channel.FundingOutnum is null
+                        ? null
+                        : new OutPoint(channel.FundingTxId, channel.FundingOutnum.Value),
                     Capacity = channel.Total,
                     IsActive = channel.State == "CHANNELD_NORMAL"
                 });

--- a/src/BTCPayServer.Lightning.CLightning/PeerChannel.cs
+++ b/src/BTCPayServer.Lightning.CLightning/PeerChannel.cs
@@ -26,6 +26,9 @@ namespace BTCPayServer.Lightning.CLightning
         [JsonConverter(typeof(NBitcoin.JsonConverters.UInt256JsonConverter))]
         public uint256 FundingTxId { get; set; }
 
+        [JsonProperty("funding_outnum")]
+        public uint? FundingOutnum { get; set; }
+
         [JsonProperty("short_channel_id")]
         [JsonConverter(typeof(JsonConverters.ShortChannelIdJsonConverter))]
         public ShortChannelId ShortChannelId { get; set; }


### PR DESCRIPTION
CLN channels do not have a short_channel_id until their funding transaction is confirmed.

The channel listing previously used short_channel_id to determine the funding output index. As a result, listing channels immediately after opening one could throw an exception and prevent the entire channel list from loading.

This change:

- Uses funding_txid and funding_outnum to build the channel point.
- Safely handles channels whose funding information is not available yet.
- Forwards the cancellation token to listpeerchannels.
- Adds regression tests for pending channels and cancellation.