### PR TITLE
c-lightning: MaxFeePercent is ignored for invoices that carry an amount

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
+++ b/src/BTCPayServer.Lightning.CLightning/CLightningClient.cs
@@ -315,6 +315,11 @@ namespace BTCPayServer.Lightning.CLightning
             return payments.Select(ToLightningPayment).ToArray();
         }
 
+        // Default of c-lightning's 'exemptfee' on the legacy 'pay' command: fees below this are
+        // accepted regardless of the percentage ceiling. xpay has no equivalent knob, so it is
+        // folded into the absolute 'maxfee' we compute from MaxFeePercent.
+        const long CLightningExemptFeeMilliSatoshi = 5000;
+
         private async Task<PayResponse> PayAsync(string bolt11, PayInvoiceParams payParams, CancellationToken cancellation = default)
         {
             var isKeysend = bolt11 == null;
@@ -343,13 +348,23 @@ namespace BTCPayServer.Lightning.CLightning
 
                 if (maxFeeFlat is null)
                 {
-                    if (payParams?.MaxFeePercent is { } feePercent && explicitAmount is not null)
+                    if (payParams?.MaxFeePercent is { } feePercent)
                     {
-                        // The 'maxfee' argument of xpay/xkeysend is expressed in millisatoshi (like the flat
-                        // MaxFeeFlat branch above), so the percentage must be applied in millisatoshi as well.
-                        // Computing it in satoshi made the fee ceiling 1000x too low, causing valid payments to
-                        // be rejected for excessive fees.
-                        maxFeeFlat = (long)(explicitAmount.ToDecimal(LightMoneyUnit.MilliSatoshi) * (decimal)feePercent / 100m);
+                        // Before the switch to xpay, MaxFeePercent was handed to 'pay' as its native
+                        // 'maxfeepercent' for every invoice, with 'exemptfee' left at its 5000msat default,
+                        // so a payment was accepted when the fee was below *either* the percentage or
+                        // 5000msat. xpay takes only an absolute 'maxfee' (which overrides both of those),
+                        // so rebuild the same ceiling here as max(percentage, exemptfee).
+                        // The percentage applies to the amount actually being paid: the explicit amount when
+                        // we supply one (keysend, or a bolt11 without an amount), otherwise the amount carried
+                        // by the invoice.
+                        var feeBase = explicitAmount ?? pr?.MinimumAmount;
+                        // 'maxfee' is expressed in millisatoshi (like the flat MaxFeeFlat branch above), so the
+                        // percentage must be applied in millisatoshi as well.
+                        if (feeBase is not null && feeBase != LightMoney.Zero)
+                            maxFeeFlat = Math.Max(
+                                (long)(feeBase.ToDecimal(LightMoneyUnit.MilliSatoshi) * (decimal)feePercent / 100m),
+                                CLightningExemptFeeMilliSatoshi);
                     }
                 }
 

--- a/tests/CLightningPayTests.cs
+++ b/tests/CLightningPayTests.cs
@@ -25,8 +25,14 @@ namespace BTCPayServer.Lightning.Tests
         const string ZeroAmountInvoice =
             "lnbc1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pkx2ctnv5sxxmmwwd5kgetjypeh2ursdae8g6twvus8g6rfwvs8qun0dfjkxaq8rkx3yf5tcsyz3d73gafnh3cax9rn449d9p5uxz9ezhhypd0elx87sjle52x86fux2ypatgddc6k63n7erqz25le42c4u4ecky03ylcqca784w";
 
-        [Fact]
-        public async Task PayMaxFeePercentIsSentInMilliSatoshi()
+        // An amount-carrying BOLT11 invoice (BOLT11 spec test vector, "1 cup coffee"):
+        // 2500 microBTC == 250_000 sat == 250_000_000 msat.
+        const string AmountInvoice =
+            "lnbc2500u1pvjluezpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdq5xysxxatsyp3k7enxv4jsxqzpuaztrnwngzn3kdzw5hydlzf03qdgm2hdq27cqv3agm2awhz5se903vruatfhq77w3ls4evs3ch9zw97j25emudupq63nyw24cg27h2rspfj9srp";
+
+        // Stands up a fake lightningd, runs the pay, and returns the captured JSON-RPC request.
+        static async Task<(string Method, JArray Params)> CapturePayRequest(
+            string bolt11, PayInvoiceParams payParams, long amountMsat, long amountSentMsat)
         {
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
@@ -59,8 +65,8 @@ namespace BTCPayServer.Lightning.Tests
                         ["status"] = "complete",
                         ["parts"] = 1,
                         ["payment_preimage"] = preimage,
-                        ["amount_msat"] = 100000000L,
-                        ["amount_sent_msat"] = 100001000L
+                        ["amount_msat"] = amountMsat,
+                        ["amount_sent_msat"] = amountSentMsat
                     }
                 };
                 var bytes = new UTF8Encoding(false).GetBytes(resp.ToString(Formatting.None));
@@ -75,26 +81,73 @@ namespace BTCPayServer.Lightning.Tests
             });
 
             var client = new CLightningClient(new Uri($"tcp://127.0.0.1:{port}"), Network.Main);
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await ((ILightningClient)client).Pay(bolt11, payParams, cts.Token);
+            await serverTask.WaitAsync(TimeSpan.FromSeconds(15));
 
+            Assert.NotNull(capturedParams);
+            return (capturedMethod, capturedParams);
+        }
+
+        [Fact]
+        public async Task PayMaxFeePercentIsSentInMilliSatoshi()
+        {
             // Pay the amountless invoice for 0.001 BTC (100_000 sat == 100_000_000 msat) with a 1% fee ceiling.
             var payParams = new PayInvoiceParams
             {
                 Amount = LightMoney.Satoshis(100_000),
                 MaxFeePercent = 1d
             };
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-            await ((ILightningClient)client).Pay(ZeroAmountInvoice, payParams, cts.Token);
-            await serverTask.WaitAsync(TimeSpan.FromSeconds(15));
+            var (method, prms) = await CapturePayRequest(ZeroAmountInvoice, payParams, 100000000L, 100001000L);
 
-            Assert.Equal("xpay", capturedMethod);
-            Assert.NotNull(capturedParams);
+            Assert.Equal("xpay", method);
             // params: [ invstring, amount_msat, maxfee ]
-            Assert.Equal(100_000_000L, capturedParams[1].Value<long>());
+            Assert.Equal(100_000_000L, prms[1].Value<long>());
 
             // 1% of 100_000_000 msat == 1_000_000 msat. xpay's 'maxfee' argument is denominated in
             // millisatoshi, so the ceiling must be 1_000_000. Computing the percentage in satoshi and
             // sending it as msat yields 1_000 (1000x too small), rejecting valid payments as too expensive.
-            Assert.Equal(1_000_000L, capturedParams[2].Value<long>());
+            Assert.Equal(1_000_000L, prms[2].Value<long>());
+        }
+
+        [Fact]
+        public async Task PayMaxFeePercentIsAppliedToInvoiceAmount()
+        {
+            // The common case: the BOLT11 already carries the amount, so PayInvoiceParams.Amount is
+            // not forwarded. MaxFeePercent must still be honoured, derived from the invoice amount.
+            var payParams = new PayInvoiceParams { MaxFeePercent = 1d };
+            var (method, prms) = await CapturePayRequest(AmountInvoice, payParams, 250000000L, 252500000L);
+
+            Assert.Equal("xpay", method);
+            // params: [ invstring, amount_msat, maxfee ]
+            // amount_msat stays null: xpay only accepts it for amountless invoices.
+            Assert.Equal(JTokenType.Null, prms[1].Type);
+
+            // 1% of the invoice's 250_000_000 msat == 2_500_000 msat. When 'maxfee' is omitted, xpay
+            // falls back to its own default of "5000msat, or 1% (whatever is greater)", so the fee
+            // ceiling configured by the user is silently not applied.
+            Assert.Equal(2_500_000L, prms[2].Value<long>());
+        }
+
+        [Fact]
+        public async Task PayMaxFeePercentKeepsExemptFeeFloorOnSmallPayments()
+        {
+            // The legacy 'pay' command left 'exemptfee' at 5000msat, so a small payment was accepted
+            // when its fee was below 5000msat even if that exceeded the percentage. xpay's 'maxfee'
+            // overrides exemptfee, so the floor has to be folded in or small payments get a ceiling
+            // an order of magnitude tighter than before.
+            var payParams = new PayInvoiceParams
+            {
+                Amount = LightMoney.Satoshis(100),
+                MaxFeePercent = 0.5d
+            };
+            var (method, prms) = await CapturePayRequest(ZeroAmountInvoice, payParams, 100000L, 105000L);
+
+            Assert.Equal("xpay", method);
+            Assert.Equal(100_000L, prms[1].Value<long>());
+
+            // 0.5% of 100_000 msat is only 500 msat; exemptfee's 5000msat floor wins.
+            Assert.Equal(5_000L, prms[2].Value<long>());
         }
     }
 }


### PR DESCRIPTION
Follow up to #183, and to the chat discussion about keeping the same behaviour we had with the old `pay` API.

### What the old behaviour was

Before the move to xpay, `MaxFeePercent` was passed straight to `pay` as its native `maxfeepercent` argument, for every invoice:

```csharp
var feePercent = maxFeeFlat is null ? payParams?.MaxFeePercent : null;
// pay: bolt11 [msatoshi] [label] [riskfactor] [maxfeepercent] [retry_for] [maxdelay] [exemptfee] ...
: new object[] { bolt11, explicitAmount?.MilliSatoshi, null, null, feePercent, null, null, ... }
```

`exemptfee` was left null, so c-lightning's 5000msat default applied. Per [the `pay` docs](https://docs.corelightning.org/reference/pay), `exemptfee` *"allows the `maxfeepercent` check to be skipped on fees that are smaller than `exemptfee`"*. So the effective ceiling was **max(5000msat, percentage)**.

### What changed

xpay takes only an absolute `maxfee`, so the percentage now has to be converted into one. That conversion is guarded on `explicitAmount is not null`:

```csharp
if (payParams?.MaxFeePercent is { } feePercent && explicitAmount is not null)
```

`explicitAmount` is only set when the invoice carries no amount, since xpay accepts `amount_msat` only in that case. So for a normal amount-carrying invoice the branch never runs, `maxfee` goes out as null, and xpay applies its own default of *"5000msat, or 1% (whatever is greater)"* instead of the configured ceiling.

#183 corrected the unit of that computation but kept the guard, and noted the gap at the time.

### Fix

Derive the percentage from the amount actually being paid (the explicit amount when we supply one, ie. keysend or a bolt11 without an amount, otherwise the amount on the invoice) and floor it at `exemptfee`'s default so small payments keep the allowance `pay` gave them:

```csharp
var feeBase = explicitAmount ?? pr?.MinimumAmount;
if (feeBase is not null && feeBase != LightMoney.Zero)
    maxFeeFlat = Math.Max(
        (long)(feeBase.ToDecimal(LightMoneyUnit.MilliSatoshi) * (decimal)feePercent / 100m),
        CLightningExemptFeeMilliSatoshi);
```

Without the floor a 100 sat payment at 0.5% would drop from a 5000msat allowance to 500msat, which is tighter than `pay` ever was.

### Tests

Three cases in the harness #183 added, all backend-free (an in-process TCP server stands in for lightningd and captures the outgoing request):

- `PayMaxFeePercentIsSentInMilliSatoshi`: existing, unchanged.
- `PayMaxFeePercentIsAppliedToInvoiceAmount`: amount-carrying invoice, 1% of 250,000 sat, asserts `maxfee` is 2,500,000 msat. Fails before this change (`maxfee` is null).
- `PayMaxFeePercentKeepsExemptFeeFloorOnSmallPayments`: 100 sat at 0.5%, asserts the 5000msat floor wins over the 500msat percentage.

Also verified end to end against a live node. Setup is `cln -> lnd -> cln_dest` on regtest with CLN v26.06.1, the middle hop charging 20,000msat base so the route costs 20,250msat. Paying a 250,000 sat invoice with `MaxFeePercent` low enough that the ceiling falls back to the 5000msat floor:

| | `maxfee` sent | result |
|---|---|---|
| 1.7.6 as released | none | `Ok`, fee paid **20,250 msat** |
| with this change | 5,000 msat | `Error`, *"Could not find route without excessive cost"* |

Worth noting for anyone reproducing this that it needs three nodes. With two the channel is direct, there is no routing fee, and `maxfee` never binds. The percentage used above is deliberately small so the ceiling lands under a cheap regtest route; on mainnet the same gap shows up whenever the configured percentage is below the 1% xpay assumes, e.g. a caller asking for 0.5% currently gets 1%.

### Notes

Reachable from the Greenfield pay-invoice endpoint, which is the only place `MaxFeePercent` is set in btcpayserver. `MaxFeeFlat` is unaffected; it was already applied unconditionally.
