### PR TITLE
fix(cln): map getinfo counters

### DIFF
--- a/src/BTCPayServer.Lightning.CLightning/GetInfoResponse.cs
+++ b/src/BTCPayServer.Lightning.CLightning/GetInfoResponse.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace BTCPayServer.Lightning.CLightning;
 
 //[{"type":"ipv4","address":"52.166.90.122","port":9735}]
@@ -10,9 +12,13 @@ public class GetInfoResponse
     public string Alias { get; set; }
     public string Network { get; set; }
     public int BlockHeight { get; set; }
+    [JsonProperty("num_peers")]
     public int NumPeers { get; set; }
+    [JsonProperty("num_pending_channels")]
     public int NumPendingChannels { get; set; }
+    [JsonProperty("num_active_channels")]
     public int NumActiveChannels { get; set; }
+    [JsonProperty("num_inactive_channels")]
     public int NumInactiveChannels { get; set; }
 
     public class GetInfoAddress


### PR DESCRIPTION
Core Lightning returns its getinfo counters using snake_case names, while the adapter deserializes the response with Newtonsoft.Json’s default resolver.

Because fields such as num_peers did not match NumPeers, they were silently left at 0. This adds explicit JSON mappings for:

- num_peers
- num_pending_channels
- num_active_channels
- num_inactive_channels