### PR TITLE
fix(lnd): bound open channel sync retries

### DIFF
--- a/src/BTCPayServer.Lightning.LND/LndClient.cs
+++ b/src/BTCPayServer.Lightning.LND/LndClient.cs
@@ -854,8 +854,8 @@ retry:
         async Task<OpenChannelResponse> ILightningClient.OpenChannel(OpenChannelRequest openChannelRequest, CancellationToken cancellation)
         {
             OpenChannelRequest.AssertIsSane(openChannelRequest);
-retry:
             int retryCount = 0;
+retry:
             cancellation.ThrowIfCancellationRequested();
             try
             {
@@ -902,7 +902,7 @@ retry:
                 if (retryCount++ > 3)
                     return new OpenChannelResponse(OpenChannelResult.NeedMoreConf);
 
-                await Task.Delay(1000);
+                await Task.Delay(1000, cancellation);
                 goto retry;
             }
             catch (SwaggerException ex) when
@@ -912,7 +912,7 @@ retry:
                 if (retryCount++ > 3)
                     return new OpenChannelResponse(OpenChannelResult.NeedMoreConf);
 
-                await Task.Delay(1000);
+                await Task.Delay(1000, cancellation);
                 goto retry;
             }
             catch (SwaggerException ex) when


### PR DESCRIPTION
LND channel opening could retry forever while the node was syncing because the retry counter was reset on every attempt.

This keeps the counter across retries, stops after five attempts, and makes the delay cancellable.