### PR TITLE
Bumping LND to 0.21.1-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -128,7 +128,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.19.3-beta-1
+    image: btcpayserver/lnd:v0.21.1-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.21.1-beta/sha256:cac93abe645c6bf4bca2c9c7118bd089976c1d6c08045f922775a31864165a6c
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.21.1-beta