### PR TITLE
Bumping LND to 0.21.2-beta

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.21.1-beta
+    image: btcpayserver/lnd:v0.21.2-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -128,7 +128,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.21.1-beta
+    image: btcpayserver/lnd:v0.21.2-beta
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.21.2-beta/sha256:21b8d37a445d901fb9329f1d3f5e0f2f215681acc03c80288c753a94772da1c6
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.21.2-beta