### PR TITLE
Bumping LND to 0.21.3-beta-1

### DIFF
--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,9 +4,10 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:29.0
+    image: btcpayserver/bitcoin:31.1
     environment:
       BITCOIN_NETWORK: regtest
+      BITCOIN_RPCUSERS: lnd
       BITCOIN_WALLETDIR: "/data/wallets"
       BITCOIN_EXTRA_ARGS: |
         rpcuser=ceiwHEbqWI83
@@ -98,14 +99,14 @@ services:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
       LND_REST_LISTEN_HOST: http://lnd:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=lnd:8080
         rpclisten=127.0.0.1:10008
         rpclisten=lnd:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=lnd:9735
@@ -133,14 +134,14 @@ services:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
       LND_REST_LISTEN_HOST: http://lnd_dest:8080
+      RPCUSER_FILE: /deps/.bitcoin/RPCUsers/lnd
       LND_EXTRA_ARGS: |
         restlisten=lnd_dest:8080
         rpclisten=127.0.0.1:10008
         rpclisten=lnd_dest:10009
         bitcoin.node=bitcoind
         bitcoind.rpchost=bitcoind:43782
-        bitcoind.rpcuser=ceiwHEbqWI83
-        bitcoind.rpcpass=DwubwWsoo3
+        bitcoind.rpcuser=lnd
         bitcoind.zmqpubrawblock=tcp://bitcoind:28332
         bitcoind.zmqpubrawtx=tcp://bitcoind:28333
         externalip=lnd_dest:9735

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -93,7 +93,7 @@ services:
 
   lnd:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"
@@ -128,7 +128,7 @@ services:
 
   lnd_dest:
     restart: unless-stopped
-    image: btcpayserver/lnd:v0.21.3-beta
+    image: btcpayserver/lnd:v0.21.3-beta-1
     environment:
       LND_CHAIN: "btc"
       LND_ENVIRONMENT: "regtest"

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   bitcoind:
     restart: unless-stopped
-    image: btcpayserver/bitcoin:31.1
+    image: btcpayserver/bitcoin:31.1-1
     environment:
       BITCOIN_NETWORK: regtest
       BITCOIN_RPCUSERS: lnd


### PR DESCRIPTION
Docker image: https://hub.docker.com/repository/docker/btcpayserver/lnd/tags/v0.21.3-beta-1
Tag: https://github.com/btcpayserver/lnd/releases/tag/basedon-v0.21.3-beta-1

This build adds support for file-based Bitcoin RPC passwords via RPCUSER_FILE (btcpayserver/lnd#14).

The test environment now exercises the new feature: bitcoind is bumped to btcpayserver/bitcoin:31.1, which provisions the lnd RPC user with a random password via BITCOIN_RPCUSERS, and both lnd test nodes authenticate through RPCUSER_FILE instead of the static rpcpassword. CLN/Eclair keep using the static credentials.